### PR TITLE
Run the CI on PRs that target the default branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,11 @@
 name: CI
 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push or pull request events but only for the default branch
   push:
-    branches: [ b2.5, b3.0, master]
+    branches: [scylla-4.x]
   pull_request:
-    branches: [ b2.5, b3.0, master]
+    branches: [scylla-4.x]
 
   workflow_dispatch:
 
@@ -33,6 +33,7 @@ jobs:
           java-version: | # order is important, the last one is the default which will be used by SBT
             11
             8
+          cache: sbt
 
       - name: sbt tests
         env:


### PR DESCRIPTION
Restore the CI that was previously running on the upstream repository.

As a second step, we should update the CI to use ScyllaDB instead of Cassandra (see #13).