### PR TITLE
Add Makefile and Scylla integration tests to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,23 +8,40 @@ on:
     branches: [scylla-4.x]
 
   workflow_dispatch:
+    inputs:
+      scala-versions:
+        description: 'Scala versions as JSON array, e.g. ["2.12.19","2.13.13"]'
+        required: false
+        default: '["2-LATEST"]'
+      cassandra-versions:
+        description: 'Cassandra versions as JSON array, e.g. ["3-LATEST","4-LATEST"]'
+        required: false
+        default: '["3-LATEST","4-LATEST","5-LATEST"]'
+      scylla-versions:
+        description: 'Scylla versions as JSON array, e.g. ["LATEST","LTS-LATEST"]'
+        required: false
+        default: '["LATEST","LTS-LATEST"]'
 
 jobs:
-  build:
+  it-tests-cassandra:
+    name: "Integration Tests for Cassandra"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        scala:  [2.12.19, 2.13.13]
-        db-version: [3.11.19, 4.0.17, 4.1.8, 5.0.4, dse-6.8.44]
+        scala:  ${{ fromJson(github.event.inputs['scala-versions'] || '["2-LATEST"]') }}
+        cassandra: ${{ fromJson(github.event.inputs['cassandra-versions'] || '["3-LATEST","4-LATEST","5-LATEST"]') }}
 
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install ccm via pip
-        # if cassandra-ccm's trunk breaks this CI, please file a report,
-        #  and temporarily switch this to @cassandra-test or @<sha> where sha is the last known working ccm commit
-        run: pip install git+https://github.com/apache/cassandra-ccm.git@trunk
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install CCM
+        run: make install-cassandra-ccm
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -35,14 +52,48 @@ jobs:
             8
           cache: sbt
 
-      - name: sbt tests
+      - name: Resolve Cassandra version
+        id: cassandra-version
+        env:
+          CASSANDRA_VERSION: ${{ matrix.cassandra }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make resolve-cassandra-version
+
+      - name: Resolve Scala version
+        id: scala-version
+        env:
+          SCALA_VERSION: ${{ matrix.scala }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make resolve-scala-version
+
+      - name: Restore CCM cache
+        uses: actions/cache/restore@v4
+        id: ccm-cache
+        with:
+          path: ~/.ccm/repository
+          key: ccm-${{ runner.os }}-${{ steps.cassandra-version.outputs.value }}
+
+      - name: Pre-download Cassandra image
+        if: steps.ccm-cache.outputs.cache-hit != 'true'
+        env:
+          CASSANDRA_VERSION: ${{ matrix.cassandra }}
+        run: make download-cassandra
+
+      - name: Save CCM cache
+        uses: actions/cache/save@v4
+        if: steps.ccm-cache.outputs.cache-hit != 'true'
+        with:
+          path: ~/.ccm/repository
+          key: ccm-${{ runner.os }}-${{ steps.cassandra-version.outputs.value }}
+
+      - name: Run tests on scala ${{ steps.scala-version.outputs.value }} for Cassandra ${{ steps.cassandra-version.outputs.value }}
         env:
           TEST_PARALLEL_TASKS: 1
-          CCM_CASSANDRA_VERSION: ${{ matrix.db-version }}
+          CASSANDRA_VERSION: ${{ matrix.cassandra }}
           PUBLISH_VERSION: test
           JAVA8_HOME: ${{ env.JAVA_HOME_8_X64 }}
           JAVA11_HOME: ${{ env.JAVA_HOME_11_X64 }}
-        run: sbt/sbt ++${{ matrix.scala }} test it:test
+        run: make test-integration-cassandra SCALA_VERSION=${{ matrix.scala }} CASSANDRA_VERSION=${{ matrix.cassandra }}
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v6
@@ -50,3 +101,84 @@ jobs:
         with:
           report_paths: '**/target/test-reports/*.xml'
           annotate_only: true
+          detailed_summary: true
+
+  it-tests-scylla:
+    name: "Integration Tests for Scylla"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        scala:  ${{ fromJson(github.event.inputs['scala-versions'] || '["2-LATEST"]') }}
+        scylla: ${{ fromJson(github.event.inputs['scylla-versions'] || '["LATEST","LTS-LATEST"]') }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install CCM
+        run: make install-scylla-ccm
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: | # order is important, the last one is the default which will be used by SBT
+            11
+            8
+          cache: sbt
+
+      - name: Resolve Scylla version
+        id: scylla-version
+        env:
+          SCYLLA_VERSION: ${{ matrix.scylla }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make resolve-scylla-version
+
+      - name: Resolve Scala version
+        id: scala-version
+        env:
+          SCALA_VERSION: ${{ matrix.scala }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make resolve-scala-version
+
+      - name: Restore CCM cache
+        uses: actions/cache/restore@v4
+        id: ccm-cache
+        with:
+          path: ~/.ccm/scylla-repository
+          key: ccm-${{ runner.os }}-${{ steps.scylla-version.outputs.value }}
+
+      - name: Pre-download Scylla image
+        if: steps.ccm-cache.outputs.cache-hit != 'true'
+        env:
+          SCYLLA_VERSION: ${{ matrix.scylla }}
+        run: make download-scylla
+
+      - name: Save CCM cache
+        uses: actions/cache/save@v4
+        if: steps.ccm-cache.outputs.cache-hit != 'true'
+        with:
+          path: ~/.ccm/repository
+          key: ccm-${{ runner.os }}-${{ steps.scylla-version.outputs.value }}
+
+      - name: Run tests on scala ${{ steps.scala-version.outputs.value }} for Scylla ${{ steps.scylla-version.outputs.value }}
+        env:
+          TEST_PARALLEL_TASKS: 1
+          SCYLLA_VERSION: ${{ matrix.scylla }}
+          PUBLISH_VERSION: test
+          JAVA8_HOME: ${{ env.JAVA_HOME_8_X64 }}
+          JAVA11_HOME: ${{ env.JAVA_HOME_11_X64 }}
+        run: make test-integration-scylla SCALA_VERSION=${{ matrix.scala }} SCYLLA_VERSION=${{ matrix.scylla }}
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v6
+        if: always()
+        with:
+          report_paths: '**/target/test-reports/*.xml'
+          annotate_only: true
+          detailed_summary: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,214 @@
+SHELL := bash
+.ONESHELL:
+
+MAKEFILE_PATH := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+SCYLLA_VERSION ?= LATEST
+JAVA_OPENS?=-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED
+JAVA_VERSION_RAW:=$(shell java -version 2>&1 | head -n 1 | sed -E 's/.*"([0-9]+((\.|_)[0-9]+)*)".*/\1/')
+JAVA_MAJOR_VERSION:=$(word 1,$(subst ., ,$(JAVA_VERSION_RAW)))
+ifeq ($(JAVA_MAJOR_VERSION),1)
+	JAVA_MAJOR_VERSION:=8
+endif
+ifeq ($(shell [ $(JAVA_MAJOR_VERSION) -ge 9 ] && echo yes),yes)
+	JAVA_TOOL_OPTIONS?=$(JAVA_OPENS)
+else
+	JAVA_OPENS:=
+	JAVA_TOOL_OPTIONS:=
+endif
+SBT_BIN?=./sbt/sbt
+SCALA_VERSION ?= 2-LATEST
+CASSANDRA_VERSION ?= 4-LATEST
+CCM_CASSANDRA_REPO ?= github.com/apache/cassandra-ccm
+CCM_CASSANDRA_VERSION ?= trunk
+CCM_SCYLLA_REPO ?= github.com/scylladb/scylla-ccm
+CCM_SCYLLA_VERSION ?= master
+
+ifeq (${CCM_CONFIG_DIR},)
+	CCM_CONFIG_DIR = ~/.ccm
+endif
+CCM_CONFIG_DIR := $(shell readlink --canonicalize ${CCM_CONFIG_DIR})
+
+export PATH := $(MAKEFILE_PATH)/bin:$(PATH)
+
+CASSANDRA_VERSION_FILE=/tmp/cassandra-version-$(CASSANDRA_VERSION).resolved
+SCYLLA_VERSION_FILE=/tmp/scylla-version-$(SCYLLA_VERSION).resolved
+SCALA_VERSION_FILE=/tmp/scala-version-$(SCALA_VERSION).resolved
+
+SBT_CMD=$(SBT_BIN) ++$${SCALA_VERSION_RESOLVED:-$$(cat "$(SCALA_VERSION_FILE)")}
+
+sbt:
+	@$(MAKE) sbt-install
+
+.prepare-bin:
+	@[[ -d "$(MAKEFILE_PATH)/bin" ]] || mkdir -p "$(MAKEFILE_PATH)/bin"
+
+.prepare-get-version: .prepare-bin
+	@if [[ ! -f "$(MAKEFILE_PATH)/bin/get-version" ]]; then
+		echo "bin/get-version is not found, installing it"
+		curl -sSLo /tmp/get-version.zip https://github.com/scylladb-actions/get-version/releases/download/v0.3.0/get-version_0.3.0_linux_amd64v3.zip
+		unzip /tmp/get-version.zip get-version -d "$(MAKEFILE_PATH)/bin" >/dev/null
+	fi
+
+.prepare-scylla-ccm:
+	@ccm --help 2>/dev/null 1>&2
+	if [[ $$? -lt 127 ]] \
+		&& grep SCYLLA ${CCM_CONFIG_DIR}/ccm-type 2>/dev/null 1>&2 \
+		&& grep ${CCM_SCYLLA_VERSION} ${CCM_CONFIG_DIR}/ccm-version 2>/dev/null 1>&2; then
+		echo "ScyllaDB CCM ${CCM_SCYLLA_VERSION} is already installed"
+	else \
+	  	$(MAKE) install-scylla-ccm; \
+	fi
+
+resolve-cassandra-version: .prepare-get-version
+	@find "${CASSANDRA_VERSION_FILE}" -mtime +0 -delete 2>/dev/null 1>&1
+	if [[ -f "${CASSANDRA_VERSION_FILE}" ]]; then
+		echo "Resolved Cassandra ${CASSANDRA_VERSION} to $$(cat ${CASSANDRA_VERSION_FILE})"
+		exit 0
+	fi
+
+	if [[ "${CASSANDRA_VERSION}" == "5-LATEST" ]]; then
+		CASSANDRA_VERSION_RESOLVED=$$(get-version -source github-tag -repo apache/cassandra -prefix "cassandra-" -out-no-prefix -filters "^[0-9]+$$.^[0-9]+$$.^[0-9]+$$ and 5.LAST.LAST" | tr -d '"')
+	elif [[ "${CASSANDRA_VERSION}" == "4-LATEST" ]]; then
+		CASSANDRA_VERSION_RESOLVED=$$(get-version -source github-tag -repo apache/cassandra -prefix "cassandra-" -out-no-prefix -filters "^[0-9]+$$.^[0-9]+$$.^[0-9]+$$ and 4.LAST.LAST" | tr -d '"')
+	elif [[ "${CASSANDRA_VERSION}" == "3-LATEST" ]]; then
+		CASSANDRA_VERSION_RESOLVED=$$(get-version -source github-tag -repo apache/cassandra -prefix "cassandra-" -out-no-prefix -filters "^[0-9]+$$.^[0-9]+$$.^[0-9]+$$ and 3.LAST.LAST" | tr -d '"')
+	elif echo "${CASSANDRA_VERSION}" | grep -P '^dse-[0-9\.]+'; then
+		CASSANDRA_VERSION_RESOLVED=${CASSANDRA_VERSION}
+	elif echo "${CASSANDRA_VERSION}" | grep -P '^[0-9]+\.[0-9]+\.[0-9]+'; then
+		CASSANDRA_VERSION_RESOLVED=${CASSANDRA_VERSION}
+	else
+		echo "Unknown Cassandra version name '${CASSANDRA_VERSION}'"
+		exit 1
+	fi
+
+	if [[ -z "$$CASSANDRA_VERSION_RESOLVED" ]]; then
+		echo "Failed to resolve Cassandra ${CASSANDRA_VERSION}"
+		exit 1
+	fi
+
+	echo "Resolved Cassandra ${CASSANDRA_VERSION} to $$CASSANDRA_VERSION_RESOLVED"
+	if [[ -n "${GITHUB_OUTPUT}" ]]; then
+		echo "value=$$CASSANDRA_VERSION_RESOLVED" >>$${GITHUB_OUTPUT}
+	fi
+	echo "$$CASSANDRA_VERSION_RESOLVED" >${CASSANDRA_VERSION_FILE}
+
+resolve-scylla-version: .prepare-get-version
+	@find "${SCYLLA_VERSION_FILE}" -mtime +0 -delete 2>/dev/null 1>&1
+	if [[ -f "${SCYLLA_VERSION_FILE}" ]]; then
+		echo "Resolved ScyllaDB ${SCYLLA_VERSION} to $$(cat ${SCYLLA_VERSION_FILE})"
+		exit 0
+	fi
+
+	if [[ "${SCYLLA_VERSION}" == "LTS-LATEST" ]]; then
+		SCYLLA_VERSION_RESOLVED=$$(get-version --source dockerhub-imagetag --repo scylladb/scylla -filters "^[0-9]{4}$$.^[0-9]+$$.^[0-9]+$$ and LAST.1.LAST" | tr -d '"')
+	elif [[ "${SCYLLA_VERSION}" == "LTS-PRIOR" ]]; then
+		SCYLLA_VERSION_RESOLVED=$$(get-version --source dockerhub-imagetag --repo scylladb/scylla -filters "^[0-9]{4}$$.^[0-9]+$$.^[0-9]+$$ and LAST-1.1.LAST" | tr -d '"')
+	elif [[ "${SCYLLA_VERSION}" == "LATEST" ]]; then
+		SCYLLA_VERSION_RESOLVED=$$(get-version --source dockerhub-imagetag --repo scylladb/scylla -filters "^[0-9]{4}$$.^[0-9]+$$.^[0-9]+$$ and LAST.LAST.LAST" | tr -d '"')
+	elif [[ "${SCYLLA_VERSION}" == "PRIOR" ]]; then
+		SCYLLA_VERSION_RESOLVED=$$(get-version --source dockerhub-imagetag --repo scylladb/scylla -filters "^[0-9]{4}$$.^[0-9]+$$.^[0-9]+$$ and LAST.LAST.LAST-1" | tr -d '"')
+	elif echo "${SCYLLA_VERSION}" | grep -P '^[0-9]+\.[0-9]+\.[0-9]+'; then
+		SCYLLA_VERSION_RESOLVED=${SCYLLA_VERSION}
+	else
+		echo "Unknown ScyllaDB version name '${SCYLLA_VERSION}'"
+		exit 1
+	fi
+
+	if [[ -z "$$SCYLLA_VERSION_RESOLVED" ]]; then
+		echo "Failed to resolve ScyllaDB '${SCYLLA_VERSION}'"
+		exit 1
+	fi
+
+	echo "Resolved ScyllaDB ${SCYLLA_VERSION} to $$SCYLLA_VERSION_RESOLVED"
+	if [[ -n "${GITHUB_OUTPUT}" ]]; then
+		echo "value=$$SCYLLA_VERSION_RESOLVED" >>$${GITHUB_OUTPUT}
+	fi
+	echo "$$SCYLLA_VERSION_RESOLVED" >${SCYLLA_VERSION_FILE}
+
+.prepare-cassandra-ccm:
+	@pip install --upgrade psutil >/dev/null
+	ccm --help 2>/dev/null 1>&2
+	if [[ $$? -lt 127 ]]
+		&& grep CASSANDRA ${CCM_CONFIG_DIR}/ccm-type 2>/dev/null 1>&2
+		&& grep ${CCM_CASSANDRA_VERSION} ${CCM_CONFIG_DIR}/ccm-version 2>/dev/null 1>&2; then
+		echo "Cassandra CCM ${CCM_CASSANDRA_VERSION} is already installed"
+	else
+	  	$(MAKE) install-cassandra-ccm
+	fi
+
+install-cassandra-ccm:
+	@echo "Installing Cassandra CCM ${CCM_CASSANDRA_VERSION} from ${CCM_CASSANDRA_REPO}"
+	pip install "git+https://${CCM_CASSANDRA_REPO}.git@${CCM_CASSANDRA_VERSION}"
+	mkdir ${CCM_CONFIG_DIR} 2>/dev/null || true
+	echo CASSANDRA > ${CCM_CONFIG_DIR}/ccm-type
+	echo ${CCM_CASSANDRA_VERSION} > ${CCM_CONFIG_DIR}/ccm-version
+
+install-scylla-ccm:
+	@echo "Installing ScyllaDB CCM ${CCM_SCYLLA_VERSION} from ${CCM_SCYLLA_REPO}"
+	pip install "git+https://${CCM_SCYLLA_REPO}.git@${CCM_SCYLLA_VERSION}"
+	mkdir ${CCM_CONFIG_DIR} 2>/dev/null || true
+	echo SCYLLA > ${CCM_CONFIG_DIR}/ccm-type
+	echo ${CCM_SCYLLA_VERSION} > ${CCM_CONFIG_DIR}/ccm-version
+
+resolve-scala-version: .prepare-get-version
+	@find "${SCALA_VERSION_FILE}" -mtime +0 -delete 2>/dev/null 1>&1
+	if [[ -f "${SCALA_VERSION_FILE}" ]]; then
+		echo "Resolved Scala ${SCALA_VERSION} to $$(cat ${SCALA_VERSION_FILE})"
+		exit 0
+	fi
+
+	if [[ "${SCALA_VERSION}" == "2-LATEST" ]]; then
+		SCALA_VERSION_RESOLVED=$$(get-version -source github-tag -repo scala/scala -prefix "v" -out-no-prefix -filters "^[0-9]+$$.^[0-9]+$$.^[0-9]+$$ and 2.LAST.LAST" | tr -d '"')
+	elif [[ "${SCALA_VERSION}" == "2-PRIOR" ]]; then
+		SCALA_VERSION_RESOLVED=$$(get-version -source github-tag -repo scala/scala -prefix "v" -out-no-prefix -filters "^[0-9]+$$.^[0-9]+$$.^[0-9]+$$ and 2.LAST-1.LAST" | tr -d '"')
+	elif [[ "${SCALA_VERSION}" == "3-LATEST" ]]; then
+		SCALA_VERSION_RESOLVED=$$(get-version -source github-tag -repo scala/scala3 -filters "^[0-9]+$$.^[0-9]+$$.^[0-9]+$$ and 3.LAST.LAST" | tr -d '"')
+	elif [[ "${SCALA_VERSION}" == "3-PRIOR" ]]; then
+		SCALA_VERSION_RESOLVED=$$(get-version -source github-tag -repo scala/scala3 -filters "^[0-9]+$$.^[0-9]+$$.^[0-9]+$$ and 3.LAST-1.LAST" | tr -d '"')
+	elif echo "${SCALA_VERSION}" | grep -P '^[0-9]+\.[0-9]+\.[0-9]+'; then
+		SCALA_VERSION_RESOLVED=${SCALA_VERSION}
+	else
+		echo "Unknown Scala version name '${SCALA_VERSION}'"
+		exit 1
+	fi
+
+	if [[ -z "$$SCALA_VERSION_RESOLVED" ]]; then
+		echo "Failed to resolve Scala ${SCALA_VERSION}"
+		exit 1
+	fi
+
+	echo "Resolved Scala ${SCALA_VERSION} to $$SCALA_VERSION_RESOLVED"
+	if [[ -n "${GITHUB_OUTPUT}" ]]; then
+		echo "value=$$SCALA_VERSION_RESOLVED" >>$${GITHUB_OUTPUT}
+	fi
+	echo "$$SCALA_VERSION_RESOLVED" >${SCALA_VERSION_FILE}
+
+download-cassandra: .prepare-cassandra-ccm resolve-cassandra-version
+	@CASSANDRA_VERSION_RESOLVED=$${CASSANDRA_VERSION_RESOLVED:-$$(cat "${CASSANDRA_VERSION_FILE}")}
+	rm -rf /tmp/download.ccm || true
+	mkdir -p /tmp/download.ccm
+	ccm create ccm_1 -i 127.0.254. -n 1:0 -v "$$CASSANDRA_VERSION_RESOLVED" --config-dir=/tmp/download.ccm
+	rm -rf /tmp/download.ccm
+
+download-scylla: .prepare-scylla-ccm resolve-scylla-version
+	@SCYLLA_VERSION_RESOLVED=$${SCYLLA_VERSION_RESOLVED:-$$(cat "${SCYLLA_VERSION_FILE}")}
+	[[ "$$SCYLLA_VERSION_RESOLVED" =~ ^[0-9]{4}\. ]] && SCYLLA_VERSION_RESOLVED="release:$${SCYLLA_VERSION_RESOLVED}"
+	rm -rf /tmp/download.ccm || true
+	mkdir -p /tmp/download.ccm
+	ccm create ccm_1 -i 127.0.254. -n 1:0 -v "$$SCYLLA_VERSION_RESOLVED" --scylla --config-dir=/tmp/download.ccm
+	rm -rf /tmp/download.ccm
+
+test-integration-cassandra: resolve-scala-version resolve-cassandra-version
+	@CASSANDRA_VERSION_RESOLVED=$${CASSANDRA_VERSION_RESOLVED:-$$(cat "${CASSANDRA_VERSION_FILE}")}
+	JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS)" CCM_CASSANDRA_VERSION="$$CASSANDRA_VERSION_RESOLVED" $(SBT_CMD) test it:test
+
+test-integration-scylla: resolve-scala-version resolve-scylla-version
+	@SCYLLA_VERSION_RESOLVED=$${SCYLLA_VERSION_RESOLVED:-$$(cat "${SCYLLA_VERSION_FILE}")}
+	[[ "$$SCYLLA_VERSION_RESOLVED" =~ ^[0-9]{4}\. ]] && SCYLLA_VERSION_RESOLVED="release:$${SCYLLA_VERSION_RESOLVED}"
+	JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS)" CCM_CASSANDRA_VERSION="$$SCYLLA_VERSION_RESOLVED" CCM_IS_SCYLLA=true $(SBT_CMD) test it:test
+
+test-unit: resolve-scala-version
+	@JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS)" $(SBT_CMD) test
+
+clean:
+	@$(SBT_BIN) clean

--- a/connector/src/it/scala/com/datastax/spark/connector/cluster/Fixtures.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/cluster/Fixtures.scala
@@ -153,6 +153,10 @@ trait AuthCluster extends SingleClusterFixture {
       Seq(sslConf.copy(dseConfiguration = sslConf.dseConfiguration ++ Map(
         "authentication_options.enabled" -> "true"
       )))
+    } else if (defaultConfig.scyllaEnabled) {
+      Seq(sslConf.copy(cassandraConfiguration = sslConf.cassandraConfiguration ++ Map(
+        "authenticator" -> "PasswordAuthenticator"
+      )))
     } else {
       if (defaultConfig.getCassandraVersion.compareTo(CcmConfig.V5_0_0) >= 0) {
         Seq(sslConf.copy(cassandraConfiguration = sslConf.cassandraConfiguration ++ Map(

--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -70,16 +70,49 @@ object Testing {
     version.exists(_.startsWith("dse-"))
   }
 
+  private lazy val javaMajorVersion: Int = {
+    val version = System.getProperty("java.version")
+    val major = if (version.startsWith("1.")) {
+      version.substring(2, 3).toInt
+    } else {
+      version.takeWhile(_ != '.').toInt
+    }
+    major
+  }
+
   def getCCMJvmOptions = {
     val dbVersion = sys.env.get("CCM_CASSANDRA_VERSION")
     val ccmVersion = dbVersion.map(version => s"-Dccm.version=${version.stripPrefix("dse-")}")
     val cassandraVersion = dbVersion.map(version => s"-Dcassandra.version=${version.stripPrefix("dse-")}")
     val ccmDse = sys.env.get("CCM_IS_DSE").map(_.toLowerCase == "true").orElse(Some(isDse(dbVersion)))
       .map(isDSE => s"-Dccm.dse=$isDSE")
+    val ccmScylla = sys.env.get("CCM_IS_SCYLLA").map(_.toLowerCase == "true")
+      .map(isScylla => s"-Dccm.scylla=$isScylla")
     val cassandraDirectory = sys.env.get("CCM_INSTALL_DIR").map(dir => s"-Dcassandra.directory=$dir")
     val ccmJava = sys.env.get("CCM_JAVA_HOME").orElse(sys.env.get("JAVA_HOME")).map(dir => s"-Dccm.java.home=$dir")
     val ccmPath = sys.env.get("CCM_JAVA_HOME").orElse(sys.env.get("JAVA_HOME")).map(dir => s"-Dccm.path=$dir/bin")
-    val options = Seq(ccmVersion, ccmDse, cassandraVersion, cassandraDirectory, ccmJava, ccmPath)
+
+    // Java 9+ module system fixes for Spark (only add for Java 9+)
+    val javaModuleOptions = if (javaMajorVersion >= 9) {
+      Seq(
+        Some("--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"),
+        Some("--add-opens=java.base/java.lang=ALL-UNNAMED"),
+        Some("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"),
+        Some("--add-opens=java.base/java.io=ALL-UNNAMED"),
+        Some("--add-opens=java.base/java.net=ALL-UNNAMED"),
+        Some("--add-opens=java.base/java.nio=ALL-UNNAMED"),
+        Some("--add-opens=java.base/java.util=ALL-UNNAMED"),
+        Some("--add-opens=java.base/java.util.concurrent=ALL-UNNAMED"),
+        Some("--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED"),
+        Some("--add-opens=java.base/sun.nio.cs=ALL-UNNAMED"),
+        Some("--add-opens=java.base/sun.security.action=ALL-UNNAMED"),
+        Some("--add-opens=java.base/sun.util.calendar=ALL-UNNAMED")
+      )
+    } else {
+      Seq.empty
+    }
+
+    val options = Seq(ccmVersion, ccmDse, ccmScylla, cassandraVersion, cassandraDirectory, ccmJava, ccmPath) ++ javaModuleOptions
     options
   }
 

--- a/test-support/src/main/scala/com/datastax/spark/connector/ccm/CcmConfig.scala
+++ b/test-support/src/main/scala/com/datastax/spark/connector/ccm/CcmConfig.scala
@@ -37,12 +37,64 @@ case class CcmConfig(
     createOptions: List[String] = List(),
     dseWorkloads: List[String] = List(),
     jmxPortOffset: Int = 0,
-    version: Version = Version.parse(System.getProperty("ccm.version", "5.0-beta1")),
+    rawVersion: String = System.getProperty("ccm.version", "5.0-beta1"),
     installDirectory: Option[String] = Option(System.getProperty("ccm.directory")),
     installBranch: Option[String] = Option(System.getProperty("ccm.branch")),
     dseEnabled: Boolean = Option(System.getProperty("ccm.dse")).exists(_.toLowerCase == "true"),
+    scyllaEnabled: Boolean = Option(System.getProperty("ccm.scylla")).exists(_.toLowerCase == "true"),
     javaVersion: Option[Int] = None,
     mode: ClusterMode = ClusterModes.fromEnvVar) {
+
+  lazy val version: Version = {
+    if (scyllaEnabled) {
+      resolveScyllaVersion(rawVersion)
+    } else {
+      Version.parse(rawVersion)
+    }
+  }
+
+  private def resolveScyllaVersion(versionStr: String): Version = {
+    // Check if it's in the format "release:x.x.x"
+    if (versionStr.startsWith("release:")) {
+      val extractedVersion = versionStr.substring(8) // Remove "release:" prefix
+      logger.info(s"Extracted version from release format: $extractedVersion")
+      try {
+        Version.parse(extractedVersion)
+      } catch {
+        case _: IllegalArgumentException =>
+          getVersionFromCcm()
+      }
+    } else {
+      // For non-standard version strings, get version from CCM
+      getVersionFromCcm()
+    }
+  }
+
+  private def getVersionFromCcm(): Version = {
+    import scala.sys.process._
+
+    val tmpDir = "/tmp/get-version"
+    val createCmd = s"""ccm create ccm_1 -i 127.0.254. -n 1:0 -v "$rawVersion" --scylla --config-dir=$tmpDir"""
+    val versionCmd = s"ccm node1 versionfrombuild --config-dir=$tmpDir"
+
+    try {
+      logger.info(s"Creating temporary CCM cluster to resolve version for: $rawVersion")
+      createCmd.!!
+      val resolvedVersion = versionCmd.!!.trim
+      logger.info(s"Resolved Scylla version: $resolvedVersion")
+      Version.parse(resolvedVersion)
+    } catch {
+      case e: Exception =>
+        throw new RuntimeException("failed to resolve scylla version", e)
+    } finally {
+      // Clean up the temporary cluster
+      try {
+        s"ccm remove --config-dir=$tmpDir".!
+      } catch {
+        case _: Exception => // Ignore cleanup errors
+      }
+    }
+  }
 
   def withSsl(keystorePath: String, keystorePassword: String): CcmConfig = {
     copy(cassandraConfiguration = cassandraConfiguration +
@@ -71,9 +123,7 @@ case class CcmConfig(
   }
 
   def getCassandraVersion: Version = {
-    if (!dseEnabled) {
-      version
-    } else {
+    if (dseEnabled) {
       val stableVersion = version.nextStable()
       if (stableVersion.compareTo(DSE_V6_0_0) >= 0) {
         Version.V4_0_0
@@ -84,6 +134,10 @@ case class CcmConfig(
       } else {
         V2_1_19
       }
+    } else if (scyllaEnabled) {
+      V3_10
+    } else {
+      version
     }
   }
 

--- a/test-support/src/main/scala/com/datastax/spark/connector/ccm/mode/ClusterModeExecutor.scala
+++ b/test-support/src/main/scala/com/datastax/spark/connector/ccm/mode/ClusterModeExecutor.scala
@@ -32,6 +32,7 @@ private[ccm] trait ClusterModeExecutor {
   protected val dir: Path
 
   protected val javaVersion: Option[Int] = config.javaVersion match {
+    case None if config.scyllaEnabled => Some(8)
     case None if config.dseEnabled => Some(8)
     case None if config.version.getMajor < 5 => Some(8)
     case None => Some(11)

--- a/test-support/src/main/scala/com/datastax/spark/connector/ccm/mode/StandardModeExecutor.scala
+++ b/test-support/src/main/scala/com/datastax/spark/connector/ccm/mode/StandardModeExecutor.scala
@@ -65,10 +65,17 @@ private[mode] trait DefaultExecutor extends ClusterModeExecutor {
       case 1 => config.jvmArgs :+ "-Dcassandra.superuser_setup_delay_ms=0" :+ "-Dcassandra.ring_delay_ms=1000" :+ "-Dcassandra.skip_sync=true"
       case _ => config.jvmArgs :+ "-Dcassandra.ring_delay_ms=5000" :+ "-Dcassandra.skip_sync=true"
     }
-    val formattedJvmArgs = jvmArgs.map(arg => s"--jvm_arg=$arg")
-    val formattedJvmVersion = javaVersion.map(v => s"--jvm-version=$v").toSeq
+    var formattedJvmArgs = jvmArgs.map(arg => s"--jvm_arg=$arg")
+    var formattedJvmVersion = javaVersion.map(v => s"--jvm-version=$v").toSeq
+    var waitOthersNotice = "--skip-wait-other-notice"
+    if (config.scyllaEnabled) {
+      // Scylla CCM does not support jvm version option and --skip-wait-other-notice, since it is skipped by default
+      formattedJvmVersion = Seq.empty
+      waitOthersNotice = ""
+      formattedJvmArgs = Seq.empty
+    }
     try {
-      execute(Seq(s"node$nodeNo", "start", "-v", "--skip-wait-other-notice") ++ formattedJvmArgs ++ formattedJvmVersion :_*)
+      execute(Seq(s"node$nodeNo", "start", "-v", waitOthersNotice) ++ formattedJvmArgs ++ formattedJvmVersion :_*)
       waitForNode(nodeNo)
     } catch {
       case NonFatal(e) =>
@@ -111,11 +118,12 @@ private[mode] trait DefaultExecutor extends ClusterModeExecutor {
       val options = config.installDirectory
         .map(dir => config.createOptions :+ s"--install-dir=${new File(dir).getAbsolutePath}")
         .orElse(config.installBranch.map(branch => config.createOptions ++ Seq("-v", s"git:${branch.trim().replaceAll("\"", "")}")))
-        .getOrElse(config.createOptions ++ Seq("-v", adjustCassandraBetaVersion(config.version.toString)))
+        .getOrElse(config.createOptions ++ Seq("-v", adjustCassandraBetaVersion(config.rawVersion)))
 
       val dseFlag = if (config.dseEnabled) Some("--dse") else None
+      val scyllaFlag = if (config.scyllaEnabled) Some("--scylla") else None
 
-      val createArgs = Seq("create", clusterName, "-i", config.ipPrefix) ++ options ++ dseFlag
+      val createArgs = Seq("create", clusterName, "-i", config.ipPrefix) ++ options ++ dseFlag ++ scyllaFlag
 
       // Check installed Directory
       val repositoryDir = Paths.get(
@@ -151,7 +159,8 @@ private[mode] trait DefaultExecutor extends ClusterModeExecutor {
           "-j", config.jmxPort(i).toString,
           "-i", config.ipOfNode(i),
           "--remote-debug-port=0") ++
-          dseFlag :+
+          dseFlag ++
+          scyllaFlag :+
           node
 
         execute(addArgs: _*)
@@ -164,7 +173,10 @@ private[mode] trait DefaultExecutor extends ClusterModeExecutor {
       config.cassandraConfiguration.foreach { case (key, value) =>
         execute("updateconf", s"$key:$value")
       }
-      if (config.getCassandraVersion.compareTo(Version.V2_2_0) >= 0 && config.getCassandraVersion.compareTo(CcmConfig.V4_1_0) < 0) {
+      if (config.scyllaEnabled) {
+        execute("updateconf", "enable_user_defined_functions:true")
+        execute("updateconf", "experimental_features:[udf]")
+      } else if (config.getCassandraVersion.compareTo(Version.V2_2_0) >= 0 && config.getCassandraVersion.compareTo(CcmConfig.V4_1_0) < 0) {
         execute("updateconf", "enable_user_defined_functions:true")
       } else if (config.getCassandraVersion.compareTo(CcmConfig.V4_1_0) >= 0) {
         execute("updateconf", "user_defined_functions_enabled:true")


### PR DESCRIPTION
## Summary

This PR adds build automation via Makefile and introduces Scylla integration tests to the CI pipeline.

### Changes

**1. Add Makefile for build automation**
- Dynamic version resolution for Scala, Cassandra, and Scylla (supports `2-LATEST`, `3-LATEST`, `LATEST`, `LTS-LATEST`, etc.)
- CCM installation targets for both Cassandra and Scylla variants
- Integration test execution targets
- Database image pre-download for CCM caching

**2. Add Scylla support to test infrastructure**
- `CCM_IS_SCYLLA` environment variable support in `CcmConfig`
- Scylla-specific JVM options and cluster settings
- Handle Scylla version format differences (e.g., `release:2025.1.10`)
- `ScyllaFixture` trait for Scylla-specific integration tests

**3. Fix Java version detection for JVM module options**
- Only add Java 9+ module options (`--add-opens`) when running on Java 9 or later
- Fixes "Could not create the Java Virtual Machine" error when running tests with Java 8

**4. Update CI workflow**
- Use Makefile targets for reproducible test execution
- Add Scylla integration tests job (tests against `LATEST` and `LTS-LATEST`)
- Add CCM caching for faster CI runs
- Support `workflow_dispatch` with configurable version matrices
- Add `GITHUB_TOKEN` for API rate limit avoidance during version resolution

### Benefits

- **Reproducibility**: CI environment can be reproduced locally using `make` targets
- **Scylla testing**: Integration tests now run against both Cassandra and Scylla
- **Faster CI**: CCM repository caching reduces build times
- **Flexibility**: Manual workflow runs can specify custom version combinations

### Usage

```bash
# Run Cassandra integration tests
make test-integration-cassandra SCALA_VERSION=2-LATEST CASSANDRA_VERSION=4-LATEST

# Run Scylla integration tests  
make test-integration-scylla SCALA_VERSION=2-LATEST SCYLLA_VERSION=LATEST

# Install CCM for Scylla
make install-scylla-ccm
```