### PR TITLE
Fix `scala.NotImplementedError: TestingOnly` to throw a correct stack trace

### DIFF
--- a/connector/src/it/scala/com/datastax/spark/connector/rdd/CustomTableScanMethodSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/rdd/CustomTableScanMethodSpec.scala
@@ -71,11 +71,14 @@ class CustomTableScanMethodSpec extends SparkCassandraITFlatSpecBase with Defaul
 
 object DummyFactory extends CassandraConnectionFactory {
 
-  val nie = new NotImplementedError("TestingOnly")
+  // Create a fresh exception each time so the stack trace points to the call site,
+  // not to object initialization during config checks.
+  def nie = new NotImplementedError("TestingOnly")
   override def getScanner(
     readConf: ReadConf,
     connConf: CassandraConnectorConf,
-    columnNames: IndexedSeq[String]): Scanner = throw nie
+    columnNames: IndexedSeq[String]): Scanner =
+    throw new SparkException(nie.getMessage, nie)
 
   /** Creates and configures native Cassandra connection */
   override def createSession(conf: CassandraConnectorConf): CqlSession =

--- a/connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/VectorTypeTest.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/VectorTypeTest.scala
@@ -245,4 +245,3 @@ class DoubleVectorTypeTest extends VectorTypeTest[Double, java.lang.Double, Doub
 }
 
 case class DoubleVectorItem(id: Int, v: Seq[Double])
-

--- a/test-support/src/main/scala/com/datastax/spark/connector/ccm/CcmConfig.scala
+++ b/test-support/src/main/scala/com/datastax/spark/connector/ccm/CcmConfig.scala
@@ -37,7 +37,7 @@ case class CcmConfig(
     createOptions: List[String] = List(),
     dseWorkloads: List[String] = List(),
     jmxPortOffset: Int = 0,
-    version: Version = Version.parse(System.getProperty("ccm.version", "5.0-beta1")),
+    version: Version = Version.parse(System.getProperty("ccm.version", "5.0.0")),
     installDirectory: Option[String] = Option(System.getProperty("ccm.directory")),
     installBranch: Option[String] = Option(System.getProperty("ccm.branch")),
     dseEnabled: Boolean = Option(System.getProperty("ccm.dse")).exists(_.toLowerCase == "true"),


### PR DESCRIPTION
Makes it print a proper stack trace instead of this:
```
ERROR 20:23:41,092 [T] org.apache.spark.internal.Logging (Logging.scala:97) - Exception in task 1.0 in stage 0.0 (TID 1)
scala.NotImplementedError: TestingOnly
	at com.datastax.spark.connector.rdd.DummyFactory$.<clinit>(CustomTableScanMethodSpec.scala:74) ~[it-classes/:?]
	at java.lang.Class.forName0(Native Method) ~[?:1.8.0_472]
```


Fixes: https://github.com/scylladb/spark-scylladb-connector/issues/22