### PR TITLE
Fix ConnectorMetricsSpec write metrics polling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,8 @@ jobs:
           PUBLISH_VERSION: test
           JAVA8_HOME: ${{ env.JAVA_HOME_8_X64 }}
           JAVA11_HOME: ${{ env.JAVA_HOME_11_X64 }}
-        run: sbt/sbt ++${{ matrix.scala }} test it:test
+        run: |
+          sbt/sbt   -Dspark.master=local[1] -Dspark.default.parallelism=1 -Dspark.sql.shuffle.partitions=1 -Dspark.ui.enabled=false ++${{ matrix.scala }} test it:test
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4

--- a/connector/src/it/scala/com/datastax/spark/connector/rdd/ConnectorMetricsSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/rdd/ConnectorMetricsSpec.scala
@@ -149,27 +149,56 @@ class ConnectorMetricsSpec extends SparkCassandraITFlatSpecBase with DefaultClus
   it should "properly measure amount of data written to Cassandra" in {
     stagesMetrics.clear()
     val rdd = ourSc.makeRDD(1 to 200, 16).map(x => (x, x))
+
+    println(s"[DEBUG] Created RDD with ${rdd.getNumPartitions} partitions (expecting 200 elements)")
+    println(s"[DEBUG] stagesMetrics queue size before saveToCassandra: ${stagesMetrics.size()}")
+
     rdd.saveToCassandra(ks, "leftjoin")
+
+    println(s"[DEBUG] saveToCassandra completed")
+    println(s"[DEBUG] stagesMetrics queue size after saveToCassandra: ${stagesMetrics.size()}")
 
     var totalRecordsWritten: Long = 0
     var totalBytesWritten: Long = 0
+    var pollCount = 0
 
     Eventually.eventually(Eventually.timeout(Span(20, Seconds))) {
-      Option(stagesMetrics.poll()).foreach { metrics =>
+      val polledMetrics = Option(stagesMetrics.poll())
+      polledMetrics.foreach { metrics =>
+        pollCount += 1
+        println(s"[DEBUG] Poll #$pollCount - Records: ${metrics.outputMetrics.recordsWritten}, Bytes: ${metrics.outputMetrics.bytesWritten}")
         totalRecordsWritten = totalRecordsWritten + metrics.outputMetrics.recordsWritten
         totalBytesWritten = totalBytesWritten + metrics.outputMetrics.bytesWritten
+        println(s"[DEBUG] Running totals - Records: $totalRecordsWritten, Bytes: $totalBytesWritten")
       }
+
+      println(s"[DEBUG] Remaining in queue: ${stagesMetrics.size()}")
+      println(s"[DEBUG] Checking assertion - Records: $totalRecordsWritten (expected 200), Bytes: $totalBytesWritten (expected ${200 * 8})")
 
       totalRecordsWritten should be(200)
       totalBytesWritten should be(200 * 8)
     }
+
+    println(s"[DEBUG] Test completed successfully - Total polls: $pollCount, Records: $totalRecordsWritten, Bytes: $totalBytesWritten")
   }
 }
 
 class ConnectorMetricsListener(conf: SparkConf) extends SparkListener {
   override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = {
-    val metrics = stageCompleted.stageInfo.taskMetrics
-    stagesMetrics.offer(ConnectorMetricsListener.snapshotMetrics(metrics))
+    val stageInfo = stageCompleted.stageInfo
+    val metrics = stageInfo.taskMetrics
+    val snapshot = ConnectorMetricsListener.snapshotMetrics(metrics)
+
+    println(s"[DEBUG] ConnectorMetricsListener - Stage ${stageInfo.stageId} completed:")
+    println(s"[DEBUG]   Stage name: ${stageInfo.name}")
+    println(s"[DEBUG]   Num tasks: ${stageInfo.numTasks}")
+    println(s"[DEBUG]   Output records: ${snapshot.outputMetrics.recordsWritten}")
+    println(s"[DEBUG]   Output bytes: ${snapshot.outputMetrics.bytesWritten}")
+    println(s"[DEBUG]   Input records: ${snapshot.inputMetrics.recordsRead}")
+    println(s"[DEBUG]   Input bytes: ${snapshot.inputMetrics.bytesRead}")
+
+    stagesMetrics.offer(snapshot)
+    println(s"[DEBUG]   Queue size after offer: ${stagesMetrics.size()}")
   }
 }
 

--- a/connector/src/it/scala/com/datastax/spark/connector/rdd/ConnectorMetricsSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/rdd/ConnectorMetricsSpec.scala
@@ -151,13 +151,17 @@ class ConnectorMetricsSpec extends SparkCassandraITFlatSpecBase with DefaultClus
     val rdd = ourSc.makeRDD(1 to 200, 16).map(x => (x, x))
     rdd.saveToCassandra(ks, "leftjoin")
 
-    Eventually.eventually(Eventually.timeout(Span(20, Seconds))) {
-      val metrics = stagesMetrics.iterator().asScala
-        .find(_.outputMetrics.recordsWritten > 0)
-        .getOrElse(fail("No output metrics recorded yet"))
+    var totalRecordsWritten: Long = 0
+    var totalBytesWritten: Long = 0
 
-      metrics.outputMetrics.recordsWritten should be(200)
-      metrics.outputMetrics.bytesWritten should be(200 * 8)
+    Eventually.eventually(Eventually.timeout(Span(20, Seconds))) {
+      val metrics = Option(stagesMetrics.poll())
+        .getOrElse(fail("No output metrics recorded yet"))
+      totalRecordsWritten = totalRecordsWritten + metrics.outputMetrics.recordsWritten
+      totalBytesWritten = totalBytesWritten + metrics.outputMetrics.bytesWritten
+
+      totalRecordsWritten should be(200)
+      totalBytesWritten should be(200 * 8)
     }
   }
 }

--- a/connector/src/it/scala/com/datastax/spark/connector/rdd/ConnectorMetricsSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/rdd/ConnectorMetricsSpec.scala
@@ -155,10 +155,10 @@ class ConnectorMetricsSpec extends SparkCassandraITFlatSpecBase with DefaultClus
     var totalBytesWritten: Long = 0
 
     Eventually.eventually(Eventually.timeout(Span(20, Seconds))) {
-      val metrics = Option(stagesMetrics.poll())
-        .getOrElse(fail("No output metrics recorded yet"))
-      totalRecordsWritten = totalRecordsWritten + metrics.outputMetrics.recordsWritten
-      totalBytesWritten = totalBytesWritten + metrics.outputMetrics.bytesWritten
+      Option(stagesMetrics.poll()).foreach { metrics =>
+        totalRecordsWritten = totalRecordsWritten + metrics.outputMetrics.recordsWritten
+        totalBytesWritten = totalBytesWritten + metrics.outputMetrics.bytesWritten
+      }
 
       totalRecordsWritten should be(200)
       totalBytesWritten should be(200 * 8)

--- a/connector/src/it/scala/com/datastax/spark/connector/rdd/ConnectorMetricsSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/rdd/ConnectorMetricsSpec.scala
@@ -25,11 +25,12 @@ import com.datastax.spark.connector._
 import com.datastax.spark.connector.cluster.{DefaultCluster, SeparateJVM}
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.rdd.ConnectorMetricsListener.stagesMetrics
-import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.scheduler.{SparkListener, SparkListenerStageCompleted}
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Seconds, Span}
+
+import scala.collection.JavaConverters._
 
 class ConnectorMetricsSpec extends SparkCassandraITFlatSpecBase with DefaultCluster with SeparateJVM {
 
@@ -149,12 +150,12 @@ class ConnectorMetricsSpec extends SparkCassandraITFlatSpecBase with DefaultClus
     stagesMetrics.clear()
     val rdd = ourSc.makeRDD(1 to 200, 16).map(x => (x, x))
     rdd.saveToCassandra(ks, "leftjoin")
-    Eventually.eventually {
-      stagesMetrics.size() should be(1)
-    }
 
     Eventually.eventually(Eventually.timeout(Span(20, Seconds))) {
-      val metrics = stagesMetrics.poll()
+      val metrics = stagesMetrics.iterator().asScala
+        .find(_.outputMetrics.recordsWritten > 0)
+        .getOrElse(fail("No output metrics recorded yet"))
+
       metrics.outputMetrics.recordsWritten should be(200)
       metrics.outputMetrics.bytesWritten should be(200 * 8)
     }
@@ -164,10 +165,26 @@ class ConnectorMetricsSpec extends SparkCassandraITFlatSpecBase with DefaultClus
 class ConnectorMetricsListener(conf: SparkConf) extends SparkListener {
   override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = {
     val metrics = stageCompleted.stageInfo.taskMetrics
-    stagesMetrics.offer(metrics)
+    stagesMetrics.offer(ConnectorMetricsListener.snapshotMetrics(metrics))
   }
 }
 
 object ConnectorMetricsListener {
-  val stagesMetrics = new LinkedTransferQueue[TaskMetrics]()
+  final case class InputMetricsSnapshot(bytesRead: Long, recordsRead: Long)
+  final case class OutputMetricsSnapshot(bytesWritten: Long, recordsWritten: Long)
+  final case class TaskMetricsSnapshot(inputMetrics: InputMetricsSnapshot, outputMetrics: OutputMetricsSnapshot)
+
+  def snapshotMetrics(metrics: org.apache.spark.executor.TaskMetrics): TaskMetricsSnapshot = {
+    val input = InputMetricsSnapshot(
+      bytesRead = metrics.inputMetrics.bytesRead,
+      recordsRead = metrics.inputMetrics.recordsRead
+    )
+    val output = OutputMetricsSnapshot(
+      bytesWritten = metrics.outputMetrics.bytesWritten,
+      recordsWritten = metrics.outputMetrics.recordsWritten
+    )
+    TaskMetricsSnapshot(input, output)
+  }
+
+  val stagesMetrics = new LinkedTransferQueue[TaskMetricsSnapshot]()
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala
@@ -72,9 +72,13 @@ class AsyncExecutor[T, R](asyncAction: T => CompletionStage[R], maxConcurrentTas
         }
 
         private def onSuccess(result: R) {
+          logInfo(s"[DEBUG] AsyncExecutor.onSuccess - Task completed successfully")
           release()
           promise.success(result)
-          successHandler.foreach(_ (task, submissionTimestamp, executionTimestamp))
+          successHandler.foreach { handler =>
+            logInfo(s"[DEBUG] AsyncExecutor.onSuccess - Calling success handler")
+            handler(task, submissionTimestamp, executionTimestamp)
+          }
         }
 
         private def onFailure(throwable: Throwable) {
@@ -90,11 +94,14 @@ class AsyncExecutor[T, R](asyncAction: T => CompletionStage[R], maxConcurrentTas
               tryFuture()
 
             case otherException =>
-              logError("Failed to execute: " + task, otherException)
+              logError(s"[DEBUG] AsyncExecutor.onFailure - Failed to execute: $task", otherException)
               latestException = Some(throwable)
               release()
               promise.failure(throwable)
-              failureHandler.foreach(_ (task, submissionTimestamp, executionTimestamp))
+              failureHandler.foreach { handler =>
+                logError(s"[DEBUG] AsyncExecutor.onFailure - Calling failure handler")
+                handler(task, submissionTimestamp, executionTimestamp)
+              }
           }
         }
 

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -249,7 +249,7 @@ class TableWriter[T] private (
   private def writeInternal(asyncStatementWriter: AsyncStatementWriter[T], taskContext: TaskContext, data: Iterator[T]) {
     val updater = OutputMetricsUpdater(taskContext, writeConf)
     val tokenRanges = extractTokenRange(taskContext.partitionId())
-    logInfo(s"Writing ranges: ${tokenRanges}")
+    logInfo(s"[DEBUG] TableWriter.writeInternal - Partition ${taskContext.partitionId()}: Writing ranges: ${tokenRanges}")
 
     val metricMonitoringWriter = asyncStatementWriter.copy(
         successHandler = Some(updater.batchFinished(success = true, _, _, _)),
@@ -257,19 +257,27 @@ class TableWriter[T] private (
 
     val rowIterator = new CountingIterator(data)
 
-    logDebug(s"Writing data partition to $keyspaceName.$tableName in batches of ${writeConf.batchSize}.")
+    logDebug(s"[DEBUG] TableWriter.writeInternal - Partition ${taskContext.partitionId()}: Writing data partition to $keyspaceName.$tableName in batches of ${writeConf.batchSize}.")
+    logInfo(s"[DEBUG] TableWriter.writeInternal - Partition ${taskContext.partitionId()}: Starting write loop")
 
+    var rowsProcessed = 0
     for (stmtToWrite <- rowIterator) {
       metricMonitoringWriter.write(stmtToWrite)
+      rowsProcessed += 1
     }
+
+    logInfo(s"[DEBUG] TableWriter.writeInternal - Partition ${taskContext.partitionId()}: Write loop completed, processed $rowsProcessed rows")
+    logInfo(s"[DEBUG] TableWriter.writeInternal - Partition ${taskContext.partitionId()}: Closing writer...")
 
     metricMonitoringWriter.close()
 
+    logInfo(s"[DEBUG] TableWriter.writeInternal - Partition ${taskContext.partitionId()}: Writer closed")
+
     val duration = updater.finish() / 1000000000d
-    logInfo(f"Wrote ${rowIterator.count} rows to $keyspaceName.$tableName in $duration%.3f s.")
+    logInfo(f"[DEBUG] TableWriter.writeInternal - Partition ${taskContext.partitionId()}: Wrote ${rowIterator.count} rows to $keyspaceName.$tableName in $duration%.3f s.")
 
     tokenRangeAcc.foreach(_.add(tokenRanges.toSet))
-    logInfo("Added token ranges to accumulator")
+    logInfo(s"[DEBUG] TableWriter.writeInternal - Partition ${taskContext.partitionId()}: Added token ranges to accumulator")
   }
 }
 

--- a/connector/src/main/scala/org/apache/spark/metrics/OutputMetricsUpdater.scala
+++ b/connector/src/main/scala/org/apache/spark/metrics/OutputMetricsUpdater.scala
@@ -145,7 +145,7 @@ object OutputMetricsUpdater extends Logging {
 
         logInfo(s"[DEBUG] OutputMetricsUpdater.updateTaskMetrics - Batch: +$count rows, +$dataLength bytes | Total: $afterRows rows (was $beforeRows), $afterBytes bytes (was $beforeBytes)")
       } else {
-        logWarn(s"[DEBUG] OutputMetricsUpdater.updateTaskMetrics - Batch FAILED: count=$count, dataLength=$dataLength")
+        logWarning(s"[DEBUG] OutputMetricsUpdater.updateTaskMetrics - Batch FAILED: count=$count, dataLength=$dataLength")
       }
     }
   }

--- a/connector/src/main/scala/org/apache/spark/metrics/OutputMetricsUpdater.scala
+++ b/connector/src/main/scala/org/apache/spark/metrics/OutputMetricsUpdater.scala
@@ -99,7 +99,7 @@ object OutputMetricsUpdater extends Logging {
   }
 
   private abstract class BaseOutputMetricsUpdater
-    extends OutputMetricsUpdater with Timer {
+    extends OutputMetricsUpdater with Timer with Logging {
 
     override def batchFinished(
       success: Boolean,
@@ -110,6 +110,9 @@ object OutputMetricsUpdater extends Logging {
 
       val dataLength = stmt.bytesCount
       val rowsCount = stmt.rowsCount
+
+      logInfo(s"[DEBUG] OutputMetricsUpdater.batchFinished - success=$success, rows=$rowsCount, bytes=$dataLength")
+
       updateTaskMetrics(success, rowsCount, dataLength)
       updateCodahaleMetrics(success, rowsCount, dataLength, submissionTimestamp, executionTimestamp)
     }
@@ -117,7 +120,7 @@ object OutputMetricsUpdater extends Logging {
     def finish(): Long = stopTimer()
   }
 
-  private trait TaskMetricsSupport extends OutputMetricsUpdater {
+  private trait TaskMetricsSupport extends OutputMetricsUpdater with Logging {
     val outputMetrics: OutputMetrics
 
     val dataLengthCounter = new LongAdder
@@ -128,10 +131,21 @@ object OutputMetricsUpdater extends Logging {
 
     override private[metrics] def updateTaskMetrics(success: Boolean, count: Int, dataLength: Int): Unit = {
       if (success) {
+        val beforeRows = rowsCounter.longValue()
+        val beforeBytes = dataLengthCounter.longValue()
+
         dataLengthCounter.add(dataLength)
         rowsCounter.add(count)
-        outputMetrics.setBytesWritten(dataLengthCounter.longValue())
-        outputMetrics.setRecordsWritten(rowsCounter.longValue())
+
+        val afterRows = rowsCounter.longValue()
+        val afterBytes = dataLengthCounter.longValue()
+
+        outputMetrics.setBytesWritten(afterBytes)
+        outputMetrics.setRecordsWritten(afterRows)
+
+        logInfo(s"[DEBUG] OutputMetricsUpdater.updateTaskMetrics - Batch: +$count rows, +$dataLength bytes | Total: $afterRows rows (was $beforeRows), $afterBytes bytes (was $beforeBytes)")
+      } else {
+        logWarn(s"[DEBUG] OutputMetricsUpdater.updateTaskMetrics - Batch FAILED: count=$count, dataLength=$dataLength")
       }
     }
   }


### PR DESCRIPTION
Makes `ConnectorMetricsSpec.properly measure amount of data written to Cassandra` more stable