### PR TITLE
Switch from Apache Cassandra driver to ScyllaDB Java driver

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,7 +49,7 @@ object Dependencies
       .exclude("org.slf4j", "log4j-over-slf4j")
 
     def driverCoreExclude(): ModuleID = module
-      .exclude("org.apache.cassandra", "java-driver-core") // doesn't shade guava
+      .exclude("com.scylladb", "java-driver-core") // doesn't shade guava
       .exclude("org.apache.tinkerpop", "*")
       // until SPARK-20075 is fixed we fallback to java workarounds for native calls
       .exclude("com.github.jnr", "jnr-posix")
@@ -60,7 +60,7 @@ object Dependencies
     val junit = "junit" % "junit" % JUnit
     val junitInterface = "com.novocode" % "junit-interface" % JUnitInterface
     val scalaTest = "org.scalatest" %% "scalatest" % ScalaTest
-    val driverMapperProcessor = "org.apache.cassandra" % "java-driver-mapper-processor" % CassandraJavaDriver
+    val driverMapperProcessor = "com.scylladb" % "java-driver-mapper-processor" % ScyllaJavaDriver
     val esriGeometry = "com.esri.geometry" % "esri-geometry-api" % EsriGeometry
   }
 
@@ -93,8 +93,8 @@ object Dependencies
   }
 
   object Driver {
-    val driverCore = "org.apache.cassandra" % "java-driver-core-shaded" % CassandraJavaDriver driverCoreExclude()
-    val driverMapper = "org.apache.cassandra" % "java-driver-mapper-runtime" % CassandraJavaDriver driverCoreExclude()
+    val driverCore = "com.scylladb" % "java-driver-core-shaded" % ScyllaJavaDriver driverCoreExclude()
+    val driverMapper = "com.scylladb" % "java-driver-mapper-runtime" % ScyllaJavaDriver driverCoreExclude()
 
     val commonsLang3 = "org.apache.commons" % "commons-lang3" % Versions.CommonsLang3
     val paranamer = "com.thoughtworks.paranamer" % "paranamer" % Versions.Paranamer

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -23,7 +23,7 @@ object Versions {
   val CommonsLang3    = "3.10"
   val Paranamer       = "2.8"
 
-  val CassandraJavaDriver = "4.18.1"
+  val ScyllaJavaDriver = "4.19.0.4"
   val EsriGeometry        = "2.2.4"
 
   val ScalaCheck      = "1.14.0"

--- a/sbt/sbt
+++ b/sbt/sbt
@@ -45,6 +45,6 @@ if [ ! -f ${JAR} ]; then
 fi
 printf "Launching sbt from ${JAR}\n"
 java \
-  -Xmx1200m -XX:MaxPermSize=350m -XX:ReservedCodeCacheSize=256m \
+  -Xmx1200m -XX:ReservedCodeCacheSize=256m \
   -jar ${JAR} \
   "$@"


### PR DESCRIPTION
## Summary
- Replace `org.apache.cassandra` driver 4.18.1 with `com.scylladb` driver 4.19.0.4
- The ScyllaDB driver is API-compatible and provides better integration with ScyllaDB
- Update driver exclusion rule for new groupId
- Remove obsolete `MaxPermSize` JVM option from sbt launcher (not supported in Java 9+)

## Test plan
- [x] Unit tests pass
- [x] Integration test `CassandraConnectorSpec` passes with ScyllaDB 2025.4.2
- [x] CI/CD integration tests with Scylla and Cassandra