### PR TITLE
Enable SSL/Auth tests for Scylla

### DIFF
--- a/connector/src/it/scala/com/datastax/spark/connector/cql/CassandraAuthenticatedConnectorSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/cql/CassandraAuthenticatedConnectorSpec.scala
@@ -37,7 +37,6 @@ class CassandraAuthenticatedConnectorSpec extends SparkCassandraITFlatSpecBase w
 
 
   "A CassandraConnector" should "authenticate with username and password when using native protocol for valid credentials provided by AuthCluster" in {
-    assumeNotScylla("scylladb/spark-scylladb-connector#28: SSL/Auth configuration format differs in Scylla")
     val conn2 = CassandraConnector(authConf)
     conn2.withSessionDo { session =>
       assert(session !== null)
@@ -46,7 +45,6 @@ class CassandraAuthenticatedConnectorSpec extends SparkCassandraITFlatSpecBase w
   }
 
   it should "authenticate valid username/password for provided credentials" in {
-    assumeNotScylla("scylladb/spark-scylladb-connector#28: SSL/Auth configuration format differs in Scylla")
     val conn2 = new CassandraConnector(defaultConnConf.copy(
       contactInfo = defaultContactInfo.copy(authConf = PasswordAuthConf("cassandra", "cassandra"))
     ))
@@ -54,7 +52,6 @@ class CassandraAuthenticatedConnectorSpec extends SparkCassandraITFlatSpecBase w
   }
 
   it should "fail to authenticate invalid username/password" in {
-    assumeNotScylla("scylladb/spark-scylladb-connector#28: SSL/Auth configuration format differs in Scylla")
     val conn2 = new CassandraConnector(defaultConnConf.copy(
       contactInfo = defaultContactInfo.copy(authConf = PasswordAuthConf("cassandra", "wrong_passoword"))
     ))
@@ -69,8 +66,6 @@ class CassandraAuthenticatedConnectorSpec extends SparkCassandraITFlatSpecBase w
   }
 
   "A DataFrame" should "read and write data with valid auth" in {
-    assumeNotScylla("scylladb/spark-scylladb-connector#28: SSL/Auth configuration format differs in Scylla")
-
     spark.conf.set(DefaultAuthConfFactory.UserNameParam.name, "cassandra")
     spark.conf.set(DefaultAuthConfFactory.PasswordParam.name, "cassandra")
 


### PR DESCRIPTION
## Summary

The `AuthCluster` fixture now properly supports Scylla's SSL/Auth configuration (added in #31), so the `CassandraAuthenticatedConnectorSpec` tests no longer need to be skipped when running against Scylla.

- Removed `assumeNotScylla` calls from all 4 tests
- Tests verified passing against Scylla 6.2.0

## Test plan

- [x] Run `CCM_IS_SCYLLA=true CCM_CASSANDRA_VERSION="release:6.2.0" ./sbt/sbt "it:testOnly *CassandraAuthenticatedConnectorSpec*"`
- [x] Verify all 4 tests pass

Fixes #28