### PR TITLE
Add release CI/CD pipeline with manual workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,15 +45,15 @@ jobs:
           distribution: 'temurin'
           cache: sbt
 
-      - name: Configure Git user
-        run: |
-          git config user.name "ScyllaDB Promoter"
-          git config user.email "github-promoter@scylladb.com"
-
       - name: Import GPG key
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
         run: echo "$PGP_SECRET" | base64 --decode | gpg --import --no-tty --batch --yes
+
+      - name: Configure Git user
+        run: |
+          git config user.name "ScyllaDB Promoter"
+          git config user.email "github-promoter@scylladb.com"
 
       - name: Prepare release
         run: make release-prepare
@@ -63,8 +63,8 @@ jobs:
         env:
           RELEASE_SKIP_TESTS: ${{ inputs.skip-tests }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_TOKEN_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}
         run: make release
 
       - name: Perform release dry-run
@@ -72,8 +72,8 @@ jobs:
         env:
           RELEASE_SKIP_TESTS: ${{ inputs.skip-tests }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_TOKEN_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}
         run: make release-dry-run
 
       - name: Upload release logs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,90 @@
-name: Release
+name: Release Spark ScyllaDB Connector
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        type: boolean
+        description: 'dry-run: run without publishing to Maven Central'
+        default: false
+
+      skip-tests:
+        type: boolean
+        description: 'skip-tests: do not run tests while releasing'
+        default: false
+
+      target-tag:
+        type: string
+        description: 'target-tag: tag or branch name to release. Use to re-release tagged releases'
+        default: scylla-4.x
 
 jobs:
-  publish:
-    name: Publish
+  release:
+    name: Release
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout Repository
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v5
+      - name: Checkout Code One Commit Before ${{ inputs.target-tag }}
+        if: inputs.target-tag != 'scylla-4.x'
+        env:
+          RELEASE_TARGET_TAG: ${{ inputs.target-tag }}
+        run: make checkout-one-commit-before
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
         with:
-          java-version: 17
-          distribution: temurin
+          java-version: '17'
+          distribution: 'temurin'
           cache: sbt
 
-      - name: Publish
-        run: sbt ci-release
+      - name: Configure Git user
+        run: |
+          git config user.name "ScyllaDB Promoter"
+          git config user.email "github-promoter@scylladb.com"
+
+      - name: Prepare release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        run: make release-prepare
+
+      - name: Perform release
+        if: inputs.dry-run == false
+        env:
+          RELEASE_SKIP_TESTS: ${{ inputs.skip-tests }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        run: make release
+
+      - name: Perform release dry-run
+        if: inputs.dry-run == true
+        env:
+          RELEASE_SKIP_TESTS: ${{ inputs.skip-tests }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        run: make release-dry-run
+
+      - name: Upload release logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbt-stdout
+          path: /tmp/spark-connector-release-logs/*.log
+
+      - name: Push changes to SCM
+        if: ${{ inputs.dry-run == false && inputs.target-tag == 'scylla-4.x' }}
+        run: |
+          git status && git log -3
+          git push origin --follow-tags -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,12 @@ jobs:
           git config user.name "ScyllaDB Promoter"
           git config user.email "github-promoter@scylladb.com"
 
-      - name: Prepare release
+      - name: Import GPG key
         env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
+        run: echo "$PGP_SECRET" | base64 --decode | gpg --import --no-tty --batch --yes
+
+      - name: Prepare release
         run: make release-prepare
 
       - name: Perform release
@@ -61,7 +63,6 @@ jobs:
         env:
           RELEASE_SKIP_TESTS: ${{ inputs.skip-tests }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         run: make release
@@ -71,7 +72,6 @@ jobs:
         env:
           RELEASE_SKIP_TESTS: ${{ inputs.skip-tests }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         run: make release-dry-run

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ SHELL := bash
 .PHONY: sbt clean test-unit test-integration-cassandra test-integration-scylla \
         resolve-cassandra-version resolve-scylla-version resolve-scala-version \
         download-cassandra download-scylla install-cassandra-ccm install-scylla-ccm \
-        generate-test-matrix lint lint-fix generate-test-certs
+        generate-test-matrix lint lint-fix generate-test-certs \
+        release-prepare release release-dry-run checkout-one-commit-before
 
 MAKEFILE_PATH := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 SCYLLA_VERSION ?= LATEST
@@ -293,3 +294,86 @@ generate-test-certs:
 clean:
 	@$(SBT_BIN) clean
 	@rm -rf "$(TLS_CERT_DIR)"
+
+# Release variables
+PGP_PASSPHRASE ?=
+PGP_SECRET ?=
+SONATYPE_USERNAME ?=
+SONATYPE_PASSWORD ?=
+RELEASE_SKIP_TESTS ?=
+RELEASE_TARGET_TAG ?=
+RELEASE_LOG_DIR := /tmp/spark-connector-release-logs
+
+.require-release-prepare-env:
+	@if [[ -z "${PGP_SECRET}" ]]; then
+		echo "PGP_SECRET is empty"
+		exit 1
+	fi
+
+.require-release-env:
+	@if [[ -z "${PGP_SECRET}" ]]; then
+		echo "PGP_SECRET is empty"
+		exit 1
+	fi
+	if [[ -z "${SONATYPE_USERNAME}" ]]; then
+		echo "SONATYPE_USERNAME is empty"
+		exit 1
+	fi
+	if [[ -z "${SONATYPE_PASSWORD}" ]]; then
+		echo "SONATYPE_PASSWORD is empty"
+		exit 1
+	fi
+
+release-prepare: .require-release-prepare-env
+	@CURRENT_VERSION=$$(grep -oP '(?<=:= ")[^"]+' version.sbt)
+	if [[ ! "$$CURRENT_VERSION" =~ -SNAPSHOT$$ ]]; then
+		echo "Current version $$CURRENT_VERSION is not a SNAPSHOT version"
+		exit 1
+	fi
+	RELEASE_VERSION=$${CURRENT_VERSION%-SNAPSHOT}
+	echo "Preparing release version $$RELEASE_VERSION"
+	echo 'ThisBuild / version := "'"$$RELEASE_VERSION"'"' > version.sbt
+	git add version.sbt
+	git commit -m "[release] prepare release $$RELEASE_VERSION"
+	git tag -a "v$$RELEASE_VERSION" -m "Release $$RELEASE_VERSION"
+	IFS='.' read -ra parts <<< "$$RELEASE_VERSION"
+	NEXT_PATCH=$$(( $${parts[2]} + 1 ))
+	NEXT_VERSION="$${parts[0]}.$${parts[1]}.$$NEXT_PATCH-SNAPSHOT"
+	echo 'ThisBuild / version := "'"$$NEXT_VERSION"'"' > version.sbt
+	git add version.sbt
+	git commit -m "[release] prepare for next development iteration"
+	echo "Release $$RELEASE_VERSION prepared. Next development version: $$NEXT_VERSION"
+
+release: .require-release-env
+	@RELEASE_TAG=$$(git describe --tags --abbrev=0 --match 'v*')
+	echo "Performing release for tag $$RELEASE_TAG"
+	git checkout "$$RELEASE_TAG"
+	mkdir -p "$(RELEASE_LOG_DIR)"
+	SBT_OPTS=""
+	if [[ "${RELEASE_SKIP_TESTS}" == "true" ]] || [[ "${RELEASE_SKIP_TESTS}" == "1" ]]; then
+		SBT_OPTS="set ThisBuild / test := {}"
+	fi
+	$(SBT_BIN) $$SBT_OPTS +publishSigned sonatypeBundleRelease \
+		> >(tee $(RELEASE_LOG_DIR)/stdout.log) \
+		2> >(tee $(RELEASE_LOG_DIR)/stderr.log)
+
+release-dry-run: .require-release-env
+	@RELEASE_TAG=$$(git describe --tags --abbrev=0 --match 'v*')
+	echo "Performing dry-run release for tag $$RELEASE_TAG"
+	git checkout "$$RELEASE_TAG"
+	mkdir -p "$(RELEASE_LOG_DIR)"
+	SBT_OPTS=""
+	if [[ "${RELEASE_SKIP_TESTS}" == "true" ]] || [[ "${RELEASE_SKIP_TESTS}" == "1" ]]; then
+		SBT_OPTS="set ThisBuild / test := {}"
+	fi
+	$(SBT_BIN) $$SBT_OPTS +publishSigned \
+		> >(tee $(RELEASE_LOG_DIR)/stdout.log) \
+		2> >(tee $(RELEASE_LOG_DIR)/stderr.log)
+
+checkout-one-commit-before:
+	@if [[ "${RELEASE_TARGET_TAG}" == v* ]]; then
+		echo "Checking out one commit before ${RELEASE_TARGET_TAG}"
+		git fetch --prune --unshallow || git fetch --prune || true
+		git checkout ${RELEASE_TARGET_TAG}~1
+		git tag -d ${RELEASE_TARGET_TAG}
+	fi

--- a/Makefile
+++ b/Makefile
@@ -296,26 +296,12 @@ clean:
 	@rm -rf "$(TLS_CERT_DIR)"
 
 # Release variables
-PGP_PASSPHRASE ?=
-PGP_SECRET ?=
-SONATYPE_USERNAME ?=
-SONATYPE_PASSWORD ?=
 RELEASE_SKIP_TESTS ?=
 RELEASE_TARGET_TAG ?=
 RELEASE_LOG_DIR := /tmp/spark-connector-release-logs
 
-.require-release-prepare-env:
-	@if [[ -z "${PGP_SECRET}" ]]; then
-		echo "PGP_SECRET is empty"
-		exit 1
-	fi
-
 .require-release-env:
-	@if [[ -z "${PGP_SECRET}" ]]; then
-		echo "PGP_SECRET is empty"
-		exit 1
-	fi
-	if [[ -z "${SONATYPE_USERNAME}" ]]; then
+	@if [[ -z "${SONATYPE_USERNAME}" ]]; then
 		echo "SONATYPE_USERNAME is empty"
 		exit 1
 	fi
@@ -324,7 +310,7 @@ RELEASE_LOG_DIR := /tmp/spark-connector-release-logs
 		exit 1
 	fi
 
-release-prepare: .require-release-prepare-env
+release-prepare:
 	@CURRENT_VERSION=$$(grep -oP '(?<=:= ")[^"]+' version.sbt)
 	if [[ ! "$$CURRENT_VERSION" =~ -SNAPSHOT$$ ]]; then
 		echo "Current version $$CURRENT_VERSION is not a SNAPSHOT version"

--- a/Makefile
+++ b/Makefile
@@ -349,11 +349,11 @@ release: .require-release-env
 	echo "Performing release for tag $$RELEASE_TAG"
 	git checkout "$$RELEASE_TAG"
 	mkdir -p "$(RELEASE_LOG_DIR)"
-	SBT_OPTS=""
+	SBT_CMDS="+publishSigned sonatypeBundleRelease"
 	if [[ "${RELEASE_SKIP_TESTS}" == "true" ]] || [[ "${RELEASE_SKIP_TESTS}" == "1" ]]; then
-		SBT_OPTS="set ThisBuild / test := {}"
+		SBT_CMDS="\"set ThisBuild / test := {}\" $$SBT_CMDS"
 	fi
-	$(SBT_BIN) $$SBT_OPTS +publishSigned sonatypeBundleRelease \
+	eval $(SBT_BIN) $$SBT_CMDS \
 		> >(tee $(RELEASE_LOG_DIR)/stdout.log) \
 		2> >(tee $(RELEASE_LOG_DIR)/stderr.log)
 
@@ -362,11 +362,11 @@ release-dry-run: .require-release-env
 	echo "Performing dry-run release for tag $$RELEASE_TAG"
 	git checkout "$$RELEASE_TAG"
 	mkdir -p "$(RELEASE_LOG_DIR)"
-	SBT_OPTS=""
+	SBT_CMDS="+publishSigned"
 	if [[ "${RELEASE_SKIP_TESTS}" == "true" ]] || [[ "${RELEASE_SKIP_TESTS}" == "1" ]]; then
-		SBT_OPTS="set ThisBuild / test := {}"
+		SBT_CMDS="\"set ThisBuild / test := {}\" $$SBT_CMDS"
 	fi
-	$(SBT_BIN) $$SBT_OPTS +publishSigned \
+	eval $(SBT_BIN) $$SBT_CMDS \
 		> >(tee $(RELEASE_LOG_DIR)/stdout.log) \
 		2> >(tee $(RELEASE_LOG_DIR)/stderr.log)
 

--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ release: .require-release-env
 	echo "Performing release for tag $$RELEASE_TAG"
 	git checkout "$$RELEASE_TAG"
 	mkdir -p "$(RELEASE_LOG_DIR)"
-	SBT_CMDS="+publishSigned sonatypeBundleRelease"
+	SBT_CMDS="+publishSigned sonaUpload sonaRelease"
 	if [[ "${RELEASE_SKIP_TESTS}" == "true" ]] || [[ "${RELEASE_SKIP_TESTS}" == "1" ]]; then
 		SBT_CMDS="\"set ThisBuild / test := {}\" $$SBT_CMDS"
 	fi
@@ -348,7 +348,7 @@ release-dry-run: .require-release-env
 	echo "Performing dry-run release for tag $$RELEASE_TAG"
 	git checkout "$$RELEASE_TAG"
 	mkdir -p "$(RELEASE_LOG_DIR)"
-	SBT_CMDS="+publishSigned"
+	SBT_CMDS="+publishSigned sonaUpload"
 	if [[ "${RELEASE_SKIP_TESTS}" == "true" ]] || [[ "${RELEASE_SKIP_TESTS}" == "1" ]]; then
 		SBT_CMDS="\"set ThisBuild / test := {}\" $$SBT_CMDS"
 	fi

--- a/build.sbt
+++ b/build.sbt
@@ -22,10 +22,13 @@ ThisBuild / pomExtra := Publishing.OurDevelopers
 ThisBuild / pomIncludeRepository := { _ => false }
 ThisBuild / scmInfo := Publishing.OurScmInfo
 
-Global / resolvers ++= Seq(
-  DefaultMavenRepository,
-  Resolver.sonatypeRepo("public")
-)
+// Publishing to Sonatype Central Portal (sbt 1.11+)
+ThisBuild / publishTo := {
+  val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
+  if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
+  else localStaging.value
+}
+ThisBuild / publishMavenStyle := true
 
 lazy val IntegrationTest = config("it") extend Test
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.0
+sbt.version=1.11.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+ThisBuild / version := "4.1.0-SNAPSHOT"


### PR DESCRIPTION
## Summary
- Rewrite release workflow from GitHub `release` event trigger to `workflow_dispatch` with inputs (dry-run, skip-tests, target-tag), matching the java-driver-4.x release pattern
- Add Makefile targets (`release-prepare`, `release`, `release-dry-run`, `checkout-one-commit-before`) with environment validation
- Add `version.sbt` for version tracking (analogous to `pom.xml` version in java-driver)
- Import GPG key explicitly before SBT publish, configure git user as ScyllaDB Promoter, upload release logs as artifacts

Fixes: https://github.com/scylladb/spark-scylladb-connector/issues/17
## Test plan
- [x] Dry-run tested on CI with `dry-run=true, skip-tests=true` — all steps passed (run [#22323410031](https://github.com/scylladb/spark-scylladb-connector/actions/runs/22323410031))
