### PR TITLE
Fix list append/prepend losing elements when batched on Scylla

### DIFF
--- a/connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -789,7 +789,7 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase with DefaultCluster {
     verifyKeyValueTable("key_value")
   }
 
-  it should "be able to append and prepend elements to a C* list" in notScylla("scylladb/spark-scylladb-connector#26: List prepend loses elements when batched") {
+  it should "be able to append and prepend elements to a C* list" in {
 
     val listElements = sc.parallelize(Seq(
       (1, Vector("One")),

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
@@ -41,6 +41,18 @@ private[connector] class BoundStatementBuilder[T](
   private val converters = columnTypes.map(ColumnType.converterToCassandra(_))
   private val buffer = Array.ofDim[Any](columnNames.size)
 
+  /** Whether the prepared statement contains an auto-timestamp placeholder that
+    * needs to be bound with a unique, incrementing microsecond timestamp per row. */
+  private val hasAutoTimestamp: Boolean = {
+    val varDefs = preparedStmt.getVariableDefinitions
+    (0 until varDefs.size()).exists(i => varDefs.get(i).getName.asInternal() == TableWriter.AutoTimestampParam)
+  }
+
+  /** Monotonically incrementing microsecond counter for auto-timestamps.
+    * Uses a global counter to guarantee uniqueness across all concurrent
+    * BoundStatementBuilder instances within the same JVM. */
+  private val autoTsCounter = BoundStatementBuilder.globalAutoTsCounter
+
 
   require(!ignoreNulls || protocolVersion.getCode >= DefaultProtocolVersion.V4.getCode,
     s"""
@@ -128,12 +140,26 @@ private[connector] class BoundStatementBuilder[T](
       val serializedValue = boundStatement.stmt.getBytesUnsafe(i)
       if (serializedValue != null) bytesCount += serializedValue.remaining()
     }
+
+    if (hasAutoTimestamp) {
+      boundStatement.update(_.setLong(TableWriter.AutoTimestampParam, autoTsCounter.getAndIncrement()))
+    }
+
     boundStatement.bytesCount = bytesCount
     boundStatement
   }
 }
 
 private[connector] object BoundStatementBuilder {
+
+  /** Global monotonically incrementing microsecond counter shared across all
+    * BoundStatementBuilder instances in the JVM. Ensures that every bound
+    * statement gets a unique timestamp even when multiple Spark tasks bind
+    * concurrently. Initialized to the current wall-clock time in microseconds
+    * so that timestamps stay in the same ballpark as server-assigned ones. */
+  private[writer] val globalAutoTsCounter =
+    new java.util.concurrent.atomic.AtomicLong(System.currentTimeMillis() * 1000)
+
   /** Calculate bound statement size in bytes. */
   def calculateDataSize(stmt: BoundStatement): Int = {
     var size = 0

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -121,7 +121,22 @@ class TableWriter[T] private (
     val setClause = (setNonCounterColumnsClause ++ setCounterColumnsClause).mkString(", ")
     val whereClause = quotedColumnNames(primaryKey).map(c => s"$c = :$c").mkString(" AND ")
 
-    s"UPDATE ${quote(keyspaceName)}.${quote(tableName)} SET $setClause WHERE $whereClause"
+    // Counter updates don't support USING TIMESTAMP.
+    // For all other UPDATEs, assign per-statement timestamps to ensure that multiple
+    // mutations to the same list within a batch get distinct timestamps. Without this,
+    // Scylla drops all but one list mutation when they share the same timestamp.
+    // See: https://github.com/scylladb/spark-scylladb-connector/issues/26
+    val usingClause = if (isCounterUpdate) {
+      ""
+    } else {
+      writeConf.timestamp match {
+        case TimestampOption(PerRowWriteOptionValue(placeholder)) => s" USING TIMESTAMP :$placeholder"
+        case TimestampOption(StaticWriteOptionValue(value)) => s" USING TIMESTAMP $value"
+        case _ => s" USING TIMESTAMP :${TableWriter.AutoTimestampParam}"
+      }
+    }
+
+    s"UPDATE ${quote(keyspaceName)}.${quote(tableName)}${usingClause} SET $setClause WHERE $whereClause"
   }
 
   private val isCounterUpdate =
@@ -322,6 +337,9 @@ case class AsyncStatementWriter[T](
 }
 
 object TableWriter {
+
+  /** Name of the auto-generated timestamp bind parameter added to UPDATE statements. */
+  private[writer] val AutoTimestampParam = "autots"
 
   private def checkMissingColumns(table: TableDef, columnNames: Seq[String]): Unit = {
     val allColumnNames = table.columns.map(_.columnName)


### PR DESCRIPTION
## Summary

- Fix Scylla dropping list mutations when multiple append/prepend operations to the same row are batched together
- Add `USING TIMESTAMP` with unique per-statement microsecond values to UPDATE queries, ensuring each list mutation gets a distinct timestamp at the CQL level
- Also adds `USING TIMESTAMP` support to the UPDATE query path for user-configured timestamps (previously only implemented for INSERT)
- Re-enable the previously-skipped `TableWriterSpec` test on Scylla

## Root Cause

The CQL binary protocol assigns a single client-side timestamp to an entire `BATCH` request. When multiple list append/prepend mutations to the same row share the same timestamp, Scylla treats them as conflicting writes and keeps only one — causing silent data loss. Cassandra handles this correctly.

## Test plan

- [x] `TableWriterSpec: should be able to append and prepend elements to a C* list` — previously skipped on Scylla, now passes
- [x] Full `TableWriterSpec` suite (66 tests) passes on Scylla
- [x] All unit tests (316 tests) pass
- [x] Lint passes

Fixes #26
