### PR TITLE
Fix AsyncExecutor retry for NodeUnavailableException

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala
@@ -19,14 +19,15 @@
 package com.datastax.spark.connector.writer
 
 import java.util.concurrent.{CompletableFuture, CompletionStage, Semaphore}
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.BiConsumer
 import com.datastax.spark.connector.util.Logging
 
 import scala.jdk.CollectionConverters._
 import scala.collection.concurrent.TrieMap
 import scala.util.Try
-import AsyncExecutor.Handler
-import com.datastax.oss.driver.api.core.{AllNodesFailedException, NoNodeAvailableException}
+import AsyncExecutor._
+import com.datastax.oss.driver.api.core.{AllNodesFailedException, NodeUnavailableException, NoNodeAvailableException}
 import com.datastax.oss.driver.api.core.connection.BusyConnectionException
 import com.datastax.oss.driver.api.core.servererrors.OverloadedException
 
@@ -35,7 +36,8 @@ import scala.concurrent.{Await, Future, Promise}
 
 /** Asynchronously executes tasks but blocks if the limit of unfinished tasks is reached. */
 class AsyncExecutor[T, R](asyncAction: T => CompletionStage[R], maxConcurrentTasks: Int,
-                          successHandler: Option[Handler[T]] = None, failureHandler: Option[Handler[T]]) extends Logging {
+                          successHandler: Option[Handler[T]] = None, failureHandler: Option[Handler[T]],
+                          maxRetries: Int = DefaultMaxRetries) extends Logging {
 
   private val semaphore = new Semaphore(maxConcurrentTasks)
   private val pendingFutures = new TrieMap[Future[R], Boolean]
@@ -47,6 +49,15 @@ class AsyncExecutor[T, R](asyncAction: T => CompletionStage[R], maxConcurrentTas
     */
   def getLatestException(): Option[Throwable] = latestException
 
+  private def isRetryable(throwable: Throwable): Boolean = throwable match {
+    case _: NoNodeAvailableException => true // must be before AllNodesFailedException (subclass)
+    case e: AllNodesFailedException =>
+      e.getAllErrors.asScala.values.flatMap(_.asScala).exists(err =>
+        err.isInstanceOf[BusyConnectionException] || err.isInstanceOf[NodeUnavailableException])
+    case _: OverloadedException => true
+    case _ => false
+  }
+
   /** Executes task asynchronously or blocks if more than `maxConcurrentTasks` limit is reached */
   def executeAsync(task: T): Future[R] = {
     val submissionTimestamp = System.nanoTime()
@@ -56,6 +67,7 @@ class AsyncExecutor[T, R](asyncAction: T => CompletionStage[R], maxConcurrentTas
     pendingFutures.put(promise.future, true)
 
     val executionTimestamp = System.nanoTime()
+    val retryCount = new AtomicInteger(0)
 
     def tryFuture(): Future[R] = {
       val value = Try(asyncAction(task)) recover {
@@ -78,23 +90,26 @@ class AsyncExecutor[T, R](asyncAction: T => CompletionStage[R], maxConcurrentTas
         }
 
         private def onFailure(throwable: Throwable): Unit = {
-          throwable match {
-            case e: AllNodesFailedException if e.getAllErrors.asScala.values.exists(_.isInstanceOf[BusyConnectionException]) =>
-              logTrace("BusyConnectionException ... Retrying")
+          if (isRetryable(throwable)) {
+            val attempt = retryCount.incrementAndGet()
+            if (attempt <= maxRetries) {
+              val delayMs = math.min(BaseRetryDelayMs * (1L << math.min(attempt - 1, MaxBackoffShift)), MaxRetryDelayMs)
+              logTrace(s"${throwable.getClass.getSimpleName} ... Retrying (attempt $attempt/$maxRetries, backoff ${delayMs}ms)")
+              Thread.sleep(delayMs)
               tryFuture()
-            case e: NoNodeAvailableException =>
-              logTrace("No Nodes Available ... Retrying")
-              tryFuture()
-            case e: OverloadedException =>
-              logTrace("Backpressure rejection ... Retrying")
-              tryFuture()
-
-            case otherException =>
-              logError("Failed to execute: " + task, otherException)
+            } else {
+              logError(s"Failed to execute after $maxRetries retries: " + task, throwable)
               latestException = Some(throwable)
               release()
               promise.failure(throwable)
               failureHandler.foreach(_ (task, submissionTimestamp, executionTimestamp))
+            }
+          } else {
+            logError("Failed to execute: " + task, throwable)
+            latestException = Some(throwable)
+            release()
+            promise.failure(throwable)
+            failureHandler.foreach(_ (task, submissionTimestamp, executionTimestamp))
           }
         }
 
@@ -126,4 +141,9 @@ class AsyncExecutor[T, R](asyncAction: T => CompletionStage[R], maxConcurrentTas
 
 object AsyncExecutor {
   type Handler[T] = (T, Long, Long) => Unit
+
+  val DefaultMaxRetries: Int = 10
+  val BaseRetryDelayMs: Long = 100
+  val MaxRetryDelayMs: Long = 5000
+  val MaxBackoffShift: Int = 6 // caps the bit shift to avoid overflow: 100 * 2^6 = 6400 -> clamped to 5000
 }

--- a/connector/src/test/scala/com/datastax/spark/connector/writer/AsyncExecutorTest.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/writer/AsyncExecutorTest.scala
@@ -19,15 +19,22 @@
 package com.datastax.spark.connector.writer
 
 import com.datastax.oss.driver.api.core.cql.{AsyncResultSet, SimpleStatement, Statement}
+import com.datastax.oss.driver.api.core.{AllNodesFailedException, NodeUnavailableException}
+import com.datastax.oss.driver.api.core.connection.BusyConnectionException
+import com.datastax.oss.driver.api.core.metadata.Node
+import com.datastax.oss.driver.api.core.servererrors.OverloadedException
 
+import java.util
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{Callable, CompletableFuture, CompletionStage}
 
 import org.junit.Assert._
 import org.junit.Test
+import org.mockito.Mockito._
 import org.scalatest.Matchers._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 class AsyncExecutorTest {
@@ -90,5 +97,99 @@ class AsyncExecutorTest {
     val value = future.value.get
     assertTrue(value.isInstanceOf[Failure[_]])
     assertTrue(value.asInstanceOf[Failure[_]].exception.isInstanceOf[IllegalStateException])
+  }
+
+  private def mockNode: Node = {
+    val node = mock(classOf[Node])
+    when(node.toString).thenReturn("Node(test)")
+    node
+  }
+
+  private def allNodesFailedWith(error: Throwable): AllNodesFailedException = {
+    val node = mockNode
+    val errors = new util.ArrayList[util.Map.Entry[Node, Throwable]]()
+    errors.add(new util.AbstractMap.SimpleEntry(node, error))
+    AllNodesFailedException.fromErrors(errors)
+  }
+
+  @Test
+  def testRetryOnNodeUnavailableException(): Unit = {
+    val attempts = new AtomicInteger(0)
+    val node = mockNode
+    val executor = new AsyncExecutor[String, String](
+      _ => {
+        val future = new CompletableFuture[String]()
+        if (attempts.incrementAndGet() <= 2) {
+          future.completeExceptionally(allNodesFailedWith(new NodeUnavailableException(node)))
+        } else {
+          future.complete("ok")
+        }
+        future
+      }, 10, None, None, maxRetries = 5
+    )
+    val result = Await.result(executor.executeAsync("task"), 30.seconds)
+    result shouldBe "ok"
+    attempts.get() shouldBe 3
+  }
+
+  @Test
+  def testRetryOnBusyConnectionException(): Unit = {
+    val attempts = new AtomicInteger(0)
+    val executor = new AsyncExecutor[String, String](
+      _ => {
+        val future = new CompletableFuture[String]()
+        if (attempts.incrementAndGet() <= 2) {
+          future.completeExceptionally(
+            allNodesFailedWith(new BusyConnectionException(100)))
+        } else {
+          future.complete("ok")
+        }
+        future
+      }, 10, None, None, maxRetries = 5
+    )
+    val result = Await.result(executor.executeAsync("task"), 30.seconds)
+    result shouldBe "ok"
+    attempts.get() shouldBe 3
+  }
+
+  @Test
+  def testRetryOnOverloadedException(): Unit = {
+    val attempts = new AtomicInteger(0)
+    val node = mockNode
+    val executor = new AsyncExecutor[String, String](
+      _ => {
+        val future = new CompletableFuture[String]()
+        if (attempts.incrementAndGet() <= 1) {
+          future.completeExceptionally(new OverloadedException(node, "overloaded"))
+        } else {
+          future.complete("ok")
+        }
+        future
+      }, 10, None, None, maxRetries = 5
+    )
+    val result = Await.result(executor.executeAsync("task"), 30.seconds)
+    result shouldBe "ok"
+    attempts.get() shouldBe 2
+  }
+
+  @Test
+  def testRetriesExhausted(): Unit = {
+    val attempts = new AtomicInteger(0)
+    val node = mockNode
+    val maxRetries = 3
+    val executor = new AsyncExecutor[String, String](
+      _ => {
+        val future = new CompletableFuture[String]()
+        attempts.incrementAndGet()
+        future.completeExceptionally(allNodesFailedWith(new NodeUnavailableException(node)))
+        future
+      }, 10, None, None, maxRetries = maxRetries
+    )
+    val future = executor.executeAsync("task")
+    val result = Await.ready(future, 30.seconds).value.get
+    assertTrue(result.isFailure)
+    assertTrue(result.failed.get.isInstanceOf[AllNodesFailedException])
+    // 1 initial + maxRetries retries
+    attempts.get() shouldBe (maxRetries + 1)
   }
 }


### PR DESCRIPTION
## Summary

- Add `NodeUnavailableException` to retryable error conditions in `AsyncExecutor` — Scylla reports this under connection pool pressure instead of `BusyConnectionException`, causing immediate failure instead of retry
- Add exponential backoff (100ms base, 5s cap) to all retry paths — previously retries had zero delay, compounding pressure on the node
- Add retry count limit (default 10) to prevent unbounded retry loops
- Fix `getAllErrors()` iteration to handle `Map<Node, List<Throwable>>` (was treating `List<Throwable>` as single `Throwable`)

## Test plan

- [x] New unit tests for retry on `NodeUnavailableException`, `BusyConnectionException`, `OverloadedException`
- [x] New unit test for retry exhaustion behavior
- [x] All 320 existing unit tests pass
- [x] Integration tests on Scylla LATEST CI

Fixes #35