### PR TITLE
Fix NotSerializableException: ShardingInfo crashes test reporter on Scylla CI

### DIFF
--- a/connector/src/it/scala/com/datastax/spark/connector/cql/SchemaSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/cql/SchemaSpec.scala
@@ -30,55 +30,57 @@ import org.scalatest.Inspectors._
 class SchemaSpec extends SparkCassandraITWordSpecBase with DefaultCluster {
   override lazy val conn = CassandraConnector(defaultConf)
 
-  conn.withSessionDo { session =>
-    createKeyspace(session)
+  override def beforeClass: Unit = {
+    conn.withSessionDo { session =>
+      createKeyspace(session)
 
-    session.execute(
-      s"""CREATE TYPE $ks.address (street varchar, city varchar, zip int)""")
-    session.execute(
-      s"""CREATE TABLE $ks.test(
-         |  k1 int,
-         |  k2 varchar,
-         |  k3 timestamp,
-         |  c1 bigint,
-         |  c2 varchar,
-         |  c3 uuid,
-         |  d1_blob blob,
-         |  d2_boolean boolean,
-         |  d3_decimal decimal,
-         |  d4_double double,
-         |  d5_float float,
-         |  d6_inet inet,
-         |  d7_int int,
-         |  d8_list list<int>,
-         |  d9_map map<int, varchar>,
-         |  d10_set frozen<set<int>>,
-         |  d11_timestamp timestamp,
-         |  d12_uuid uuid,
-         |  d13_timeuuid timeuuid,
-         |  d14_varchar varchar,
-         |  d15_varint varint,
-         |  d16_address frozen<address>,
-         |  PRIMARY KEY ((k1, k2, k3), c1, c2, c3)
-         |)
-      """.stripMargin)
-    session.execute(
-      s"""CREATE INDEX test_d9_map_idx ON $ks.test (keys(d9_map))""")
-    session.execute(
-      s"""CREATE INDEX test_d9_m23423ap_idx ON $ks.test (full(d10_set))""")
-    session.execute(
-      s"""CREATE INDEX test_d7_int_idx ON $ks.test (d7_int)""")
-    from(Some(CcmConfig.V5_0_0), None) {
-      session.execute(s"ALTER TABLE $ks.test ADD d17_vector frozen<vector<int,3>>")
-    }
+      session.execute(
+        s"""CREATE TYPE $ks.address (street varchar, city varchar, zip int)""")
+      session.execute(
+        s"""CREATE TABLE $ks.test(
+           |  k1 int,
+           |  k2 varchar,
+           |  k3 timestamp,
+           |  c1 bigint,
+           |  c2 varchar,
+           |  c3 uuid,
+           |  d1_blob blob,
+           |  d2_boolean boolean,
+           |  d3_decimal decimal,
+           |  d4_double double,
+           |  d5_float float,
+           |  d6_inet inet,
+           |  d7_int int,
+           |  d8_list list<int>,
+           |  d9_map map<int, varchar>,
+           |  d10_set frozen<set<int>>,
+           |  d11_timestamp timestamp,
+           |  d12_uuid uuid,
+           |  d13_timeuuid timeuuid,
+           |  d14_varchar varchar,
+           |  d15_varint varint,
+           |  d16_address frozen<address>,
+           |  PRIMARY KEY ((k1, k2, k3), c1, c2, c3)
+           |)
+        """.stripMargin)
+      session.execute(
+        s"""CREATE INDEX test_d9_map_idx ON $ks.test (keys(d9_map))""")
+      session.execute(
+        s"""CREATE INDEX test_d9_m23423ap_idx ON $ks.test (full(d10_set))""")
+      session.execute(
+        s"""CREATE INDEX test_d7_int_idx ON $ks.test (d7_int)""")
+      from(Some(CcmConfig.V5_0_0), None) {
+        session.execute(s"ALTER TABLE $ks.test ADD d17_vector frozen<vector<int,3>>")
+      }
 
-    for (i <- 0 to 9) {
-      session.execute(s"insert into $ks.test (k1,k2,k3,c1,c2,c3,d10_set) " +
-        s"values ($i, 'text$i', $i, $i, 'text$i', 123e4567-e89b-12d3-a456-42661417400$i, {$i, ${i*10}})")
+      for (i <- 0 to 9) {
+        session.execute(s"insert into $ks.test (k1,k2,k3,c1,c2,c3,d10_set) " +
+          s"values ($i, 'text$i', $i, $i, 'text$i', 123e4567-e89b-12d3-a456-42661417400$i, {$i, ${i * 10}})")
+      }
     }
   }
 
-  val schema = schemaFromCassandra(conn)
+  lazy val schema = schemaFromCassandra(conn)
 
   "A Schema" should {
     "allow to get a list of keyspaces" in {
@@ -110,8 +112,8 @@ class SchemaSpec extends SparkCassandraITWordSpecBase with DefaultCluster {
   }
 
   "A TableDef" should {
-    val keyspace = schema.keyspaceByName(ks)
-    val table = keyspace.tableByName("test")
+    lazy val keyspace = schema.keyspaceByName(ks)
+    lazy val table = keyspace.tableByName("test")
 
     "allow to read column definitions by name" in {
       table.columnByName("k1").columnName shouldBe "k1"

--- a/connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -83,10 +83,11 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase with DefaultCluster 
   override lazy val conn = CassandraConnector(defaultConf)
   val bigTableRowCount = 100000
 
-  conn.withSessionDo { session =>
-    createKeyspace(session)
+  override def beforeClass: Unit = {
+    conn.withSessionDo { session =>
+      createKeyspace(session)
 
-    awaitAll(
+      awaitAll(
       Future {
         skipIfProtocolVersionLT(V4) {
           markup(s"Making PV4 Types")
@@ -330,6 +331,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase with DefaultCluster 
       }
     )
     executor.waitForCurrentlyExecutingTasks()
+    }
   }
 
   "A CassandraRDD" should "allow to read a Cassandra table as Array of CassandraRow" in {

--- a/connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/TokenGeneratorSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/TokenGeneratorSpec.scala
@@ -40,33 +40,35 @@ class TokenGeneratorSpec extends SparkCassandraITFlatSpecBase with DefaultCluste
   val simpleKeys = Seq(1, -500, 2801, 4000000, -95500).map(SimpleKey(_))
   val complexKey = simpleKeys.map{ case SimpleKey(x) => ComplexKey(x, x, x.toString)}
 
-  conn.withSessionDo { session =>
-    createKeyspace(session)
-    val executor = getExecutor(session)
-    awaitAll(
-      Future{session.execute(s"CREATE TABLE $ks.simple(key INT PRIMARY KEY)")},
-      Future{session.execute(s"CREATE TABLE $ks.complex(key1 INT, key2 INT, key3 text, PRIMARY KEY ((key1, key2, key3)))")}
-    )
-    val simplePS = session.prepare(s"INSERT INTO $ks.simple (key) VALUES (?)")
-    val complexPS = session.prepare(s"INSERT INTO $ks.complex (key1, key2, key3) VALUES (?, ?, ?)")
-    awaitAll {
-      simpleKeys.map(simpleKey =>
-        executor.executeAsync(simplePS.bind(simpleKey.key: java.lang.Integer))) ++
-      complexKey.map(complexKey =>
-        executor.executeAsync(complexPS.bind(
-          complexKey.key1: java.lang.Integer,
-          complexKey.key2: java.lang.Integer,
-          complexKey.key3: java.lang.String)))
+  override def beforeClass: Unit = {
+    conn.withSessionDo { session =>
+      createKeyspace(session)
+      val executor = getExecutor(session)
+      awaitAll(
+        Future{session.execute(s"CREATE TABLE $ks.simple(key INT PRIMARY KEY)")},
+        Future{session.execute(s"CREATE TABLE $ks.complex(key1 INT, key2 INT, key3 text, PRIMARY KEY ((key1, key2, key3)))")}
+      )
+      val simplePS = session.prepare(s"INSERT INTO $ks.simple (key) VALUES (?)")
+      val complexPS = session.prepare(s"INSERT INTO $ks.complex (key1, key2, key3) VALUES (?, ?, ?)")
+      awaitAll {
+        simpleKeys.map(simpleKey =>
+          executor.executeAsync(simplePS.bind(simpleKey.key: java.lang.Integer))) ++
+        complexKey.map(complexKey =>
+          executor.executeAsync(complexPS.bind(
+            complexKey.key1: java.lang.Integer,
+            complexKey.key2: java.lang.Integer,
+            complexKey.key3: java.lang.String)))
+      }
+      executor.waitForCurrentlyExecutingTasks()
     }
-    executor.waitForCurrentlyExecutingTasks()
   }
 
-  val simpleTokenMap: Map[SimpleKey, Token] = conn.withSessionDo { session =>
+  lazy val simpleTokenMap: Map[SimpleKey, Token] = conn.withSessionDo { session =>
     val resultSet = session.execute(s"SELECT key, TOKEN(key) FROM $ks.simple").all().asScala
     resultSet.map(row => SimpleKey(row.getInt("key")) -> row.getToken(1)).toMap
   }
 
-  val complexTokenMap: Map[ComplexKey, Token] = conn.withSessionDo { session =>
+  lazy val complexTokenMap: Map[ComplexKey, Token] = conn.withSessionDo { session =>
     val resultSet = session
       .execute(s"SELECT key1, key2, key3, TOKEN(key1, key2, key3) FROM $ks.complex")
       .all()
@@ -78,13 +80,13 @@ class TokenGeneratorSpec extends SparkCassandraITFlatSpecBase with DefaultCluste
     ).toMap
   }
 
-  val simpleTableDef = schemaFromCassandra(conn, Some(ks), Some("simple")).tables.head
-  val complexTableDef = schemaFromCassandra(conn, Some(ks), Some("complex")).tables.head
+  lazy val simpleTableDef = schemaFromCassandra(conn, Some(ks), Some("simple")).tables.head
+  lazy val complexTableDef = schemaFromCassandra(conn, Some(ks), Some("complex")).tables.head
 
-  val simpleRW = implicitly[RowWriterFactory[SimpleKey]]
+  lazy val simpleRW = implicitly[RowWriterFactory[SimpleKey]]
     .rowWriter(simpleTableDef, PartitionKeyColumns.selectFrom(simpleTableDef))
 
-  val complexRW = implicitly[RowWriterFactory[ComplexKey]]
+  lazy val complexRW = implicitly[RowWriterFactory[ComplexKey]]
     .rowWriter(complexTableDef, PartitionKeyColumns.selectFrom(complexTableDef))
 
   "TokenGenerators" should "be able to determine simple partition keys" in {

--- a/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSelectUdtSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSelectUdtSpec.scala
@@ -29,45 +29,47 @@ import org.scalatest.concurrent.Eventually
 class CassandraDataFrameSelectUdtSpec extends SparkCassandraITFlatSpecBase with DefaultCluster with Eventually with Matchers {
   override lazy val conn = CassandraConnector(defaultConf)
 
-  conn.withSessionDo { session =>
-    createKeyspace(session)
+  override def beforeClass: Unit = {
+    conn.withSessionDo { session =>
+      createKeyspace(session)
 
-    session.execute(
-      s"""CREATE TYPE ${ks}.embedded(
-        |        a TEXT,
-        |        b INT
-        |    )""".stripMargin
-    )
+      session.execute(
+        s"""CREATE TYPE ${ks}.embedded(
+          |        a TEXT,
+          |        b INT
+          |    )""".stripMargin
+      )
 
-    session.execute(
-      s"""CREATE TABLE ${ks}.crash_test(
-        |        id INT,
-        |        embeddeds LIST<FROZEN<embedded>>,
-        |        single embedded,
-        |        embedded_map MAP<INT, FROZEN<embedded>>,
-        |        embedded_set SET<FROZEN<embedded>>,
-        |        simple_tuple TUPLE <TEXT, INT>,
-        |        simple_tuples LIST<FROZEN<TUPLE<TEXT, INT>>>,
-        |        PRIMARY KEY (id)
-        |    )""".stripMargin
-    )
+      session.execute(
+        s"""CREATE TABLE ${ks}.crash_test(
+          |        id INT,
+          |        embeddeds LIST<FROZEN<embedded>>,
+          |        single embedded,
+          |        embedded_map MAP<INT, FROZEN<embedded>>,
+          |        embedded_set SET<FROZEN<embedded>>,
+          |        simple_tuple TUPLE <TEXT, INT>,
+          |        simple_tuples LIST<FROZEN<TUPLE<TEXT, INT>>>,
+          |        PRIMARY KEY (id)
+          |    )""".stripMargin
+      )
 
-    session.execute(
-      s"""INSERT INTO ${ks}.crash_test JSON '{"id": 1, "embeddeds": [], "embedded_map": {}, "embedded_set": [], "simple_tuples": []}'"""
-    )
-    session.execute(
-      s"""INSERT INTO ${ks}.crash_test JSON
-         |'{
-         |  "id": 2,
-         |  "single": {"a": "a1", "b": 1},
-         |  "embeddeds": [{"a": "x1", "b": 1}, {"a": "x2", "b": 2}],
-         |  "embedded_map": {"1": {"a": "x1", "b": 1}, "2": {"a": "x2", "b": 2}},
-         |  "embedded_set": [{"a": "x1", "b": 1}, {"a": "x2", "b": 2}],
-         |  "simple_tuple": ["x1", 1],
-         |  "simple_tuples": [["x1", 1], ["x2", 2]]
-         |}'
-         |""".stripMargin
-    )
+      session.execute(
+        s"""INSERT INTO ${ks}.crash_test JSON '{"id": 1, "embeddeds": [], "embedded_map": {}, "embedded_set": [], "simple_tuples": []}'"""
+      )
+      session.execute(
+        s"""INSERT INTO ${ks}.crash_test JSON
+           |'{
+           |  "id": 2,
+           |  "single": {"a": "a1", "b": 1},
+           |  "embeddeds": [{"a": "x1", "b": 1}, {"a": "x2", "b": 2}],
+           |  "embedded_map": {"1": {"a": "x1", "b": 1}, "2": {"a": "x2", "b": 2}},
+           |  "embedded_set": [{"a": "x1", "b": 1}, {"a": "x2", "b": 2}],
+           |  "simple_tuple": ["x1", 1],
+           |  "simple_tuples": [["x1", 1], ["x2", 2]]
+           |}'
+           |""".stripMargin
+      )
+    }
   }
 
   trait Env {

--- a/connector/src/it/scala/com/datastax/spark/connector/util/MultiThreadedSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/util/MultiThreadedSpec.scala
@@ -34,17 +34,19 @@ class MultiThreadedSpec extends SparkCassandraITFlatSpecBase with DefaultCluster
 
   val tab = "mt_test"
 
-  conn.withSessionDo { session =>
-    createKeyspace(session)
-    val executor = getExecutor(session)
-    session.execute(s"CREATE TABLE $ks.$tab (pkey int PRIMARY KEY, value varchar)")
-    val ps = session.prepare(s"INSERT INTO $ks.$tab (pkey, value) VALUES (?, ?)")
+  override def beforeClass: Unit = {
+    conn.withSessionDo { session =>
+      createKeyspace(session)
+      val executor = getExecutor(session)
+      session.execute(s"CREATE TABLE $ks.$tab (pkey int PRIMARY KEY, value varchar)")
+      val ps = session.prepare(s"INSERT INTO $ks.$tab (pkey, value) VALUES (?, ?)")
 
-    awaitAll(
-      for (i <- 1 to count) yield
-        executor.executeAsync(ps.bind(i: java.lang.Integer, "value " + i))
-    )
-    executor.waitForCurrentlyExecutingTasks()
+      awaitAll(
+        for (i <- 1 to count) yield
+          executor.executeAsync(ps.bind(i: java.lang.Integer, "value " + i))
+      )
+      executor.waitForCurrentlyExecutingTasks()
+    }
   }
 
   "A Spark Context " should " be able to read a Cassandra table in different threads" in {

--- a/connector/src/it/scala/com/datastax/spark/connector/writer/BoundStatementBuilderSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/writer/BoundStatementBuilderSpec.scala
@@ -29,15 +29,17 @@ import com.datastax.spark.connector.util.schemaFromCassandra
 class BoundStatementBuilderSpec extends SparkCassandraITFlatSpecBase with DefaultCluster {
   override lazy val conn = CassandraConnector(defaultConf)
 
-  conn.withSessionDo { session =>
-    createKeyspace(session, ks)
-    session.execute( s"""CREATE TABLE IF NOT EXISTS "$ks".tab (id INT PRIMARY KEY, value TEXT)""")
+  override def beforeClass: Unit = {
+    conn.withSessionDo { session =>
+      createKeyspace(session, ks)
+      session.execute( s"""CREATE TABLE IF NOT EXISTS "$ks".tab (id INT PRIMARY KEY, value TEXT)""")
+    }
   }
 
-  val schema = schemaFromCassandra(conn, Some(ks), Some("tab"))
-  val rowWriter = RowWriterFactory.defaultRowWriterFactory[(Int, CassandraOption[String])]
+  lazy val schema = schemaFromCassandra(conn, Some(ks), Some("tab"))
+  lazy val rowWriter = RowWriterFactory.defaultRowWriterFactory[(Int, CassandraOption[String])]
     .rowWriter(schema.tables.head, IndexedSeq("id", "value"))
-  val ps = conn.withSessionDo(session =>
+  lazy val ps = conn.withSessionDo(session =>
     session.prepare( s"""INSERT INTO "$ks".tab (id, value) VALUES (?, ?) """))
 
   val PVGt4 = Seq(DefaultProtocolVersion.V4, DefaultProtocolVersion.V5, DseProtocolVersion.DSE_V1, DseProtocolVersion.DSE_V2)

--- a/connector/src/it/scala/com/datastax/spark/connector/writer/GroupingBatchBuilderSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/writer/GroupingBatchBuilderSpec.scala
@@ -31,13 +31,15 @@ import scala.util.Random
 class GroupingBatchBuilderSpec extends SparkCassandraITFlatSpecBase with DefaultCluster {
   override lazy val conn = CassandraConnector(defaultConf)
 
-  conn.withSessionDo { session =>
-    createKeyspace(session)
-    session.execute(s"""CREATE TABLE $ks.tab (id INT PRIMARY KEY, value TEXT)""")
+  override def beforeClass: Unit = {
+    conn.withSessionDo { session =>
+      createKeyspace(session)
+      session.execute(s"""CREATE TABLE $ks.tab (id INT PRIMARY KEY, value TEXT)""")
+    }
   }
 
-  val schema = schemaFromCassandra(conn, Some(ks), Some("tab"))
-  val rowWriter = RowWriterFactory.defaultRowWriterFactory[(Int, String)].rowWriter(schema.tables.head, IndexedSeq("id", "value"))
+  lazy val schema = schemaFromCassandra(conn, Some(ks), Some("tab"))
+  lazy val rowWriter = RowWriterFactory.defaultRowWriterFactory[(Int, String)].rowWriter(schema.tables.head, IndexedSeq("id", "value"))
 
   def makeBatchBuilder(session: CqlSession): (RichBoundStatementWrapper => Any, BatchSize, Int, Iterator[(Int, String)]) => GroupingBatchBuilder[(Int, String)] = {
     val protocolVersion = session.getContext.getProtocolVersion


### PR DESCRIPTION
## Summary

- Move database initialization from class constructor body into `beforeClass` in 8 integration test specs, bringing it under the existing `wrapUnserializableExceptions` protection
- Convert dependent `val` declarations to `lazy val` so they evaluate after `beforeClass` completes

## Root Cause

`SparkCassandraITSpecBase` wraps `beforeClass`/`afterAll`/`withFixture` with `wrapUnserializableExceptions()` to handle non-serializable driver exceptions in ScalaTest's forked test reporter. However, 8 test specs had `conn.withSessionDo { ... }` blocks running directly in the class body (during construction), bypassing this protection entirely.

When the ScyllaDB driver throws `AllNodesFailedException` containing a non-serializable `ShardingInfo` reference, the forked reporter fails to serialize the `SuiteAborted` event, causing CI exit code 2 despite all 434 tests passing.

Upstream issue for making `ShardingInfo` serializable: scylladb/java-driver#805

## Affected Files

- `CassandraRDDSpec` - largest init block (lines 86-333)
- `SchemaSpec`
- `TokenGeneratorSpec`
- `CassandraDataFrameMetadataSpec`
- `CassandraDataFrameSelectUdtSpec`
- `MultiThreadedSpec`
- `BoundStatementBuilderSpec`
- `GroupingBatchBuilderSpec`

## Test plan

- [x] `sbt compile` passes
- [x] `sbt it:compile` passes
- [x] Integration tests pass on Scylla CI (same results, no exit code 2)

Fixes #38