### PR TITLE
CI: Speed up integration tests with compile caching and parallelism

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,8 +37,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    name: "Lint"
+  compile:
+    name: "Compile"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -68,6 +68,57 @@ jobs:
           restore-keys: |
             maven-${{ runner.os }}-
 
+      - name: Compile all modules
+        run: SCALA_VERSION=${{ inputs.scala-versions || '2-LATEST' }} make compile
+
+      - name: Cache compiled classes
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            **/target/scala-*
+            **/target/streams
+          key: compiled-${{ runner.os }}-${{ github.sha }}-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/*.scala') }}
+
+  lint:
+    name: "Lint"
+    needs: compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Restore SBT cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.cache/coursier
+          key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/*.scala') }}
+          restore-keys: |
+            sbt-${{ runner.os }}-
+
+      - name: Restore Maven cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/*.scala') }}
+          restore-keys: |
+            maven-${{ runner.os }}-
+
+      - name: Restore compiled classes
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            **/target/scala-*
+            **/target/streams
+          key: compiled-${{ runner.os }}-${{ github.sha }}-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/*.scala') }}
+
       - name: Run scalastyle
         run: make lint
 
@@ -85,7 +136,7 @@ jobs:
 
   test:
     name: "${{ matrix.db-type }} ${{ matrix.db-version }} / scala ${{ matrix.scala }}"
-    needs: prepare
+    needs: [compile, prepare]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -149,6 +200,14 @@ jobs:
           key: maven-${{ runner.os }}-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/*.scala') }}
           restore-keys: |
             maven-${{ runner.os }}-
+
+      - name: Restore compiled classes
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            **/target/scala-*
+            **/target/streams
+          key: compiled-${{ runner.os }}-${{ github.sha }}-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/*.scala') }}
 
       - name: Resolve database version
         id: db-version

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := bash
 .ONESHELL:
 
-.PHONY: sbt clean test-unit test-integration-cassandra test-integration-scylla \
+.PHONY: sbt clean compile test-unit test-integration-cassandra test-integration-scylla \
         resolve-cassandra-version resolve-scylla-version resolve-scala-version \
         download-cassandra download-scylla install-cassandra-ccm install-scylla-ccm \
         generate-test-matrix lint lint-fix generate-test-certs \
@@ -276,6 +276,9 @@ test-integration-scylla: resolve-scala-version resolve-scylla-version generate-t
 		SCYLLA_VERSION_RESOLVED="release:$$SCYLLA_VERSION_RESOLVED"
 	fi
 	JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS)" CCM_CASSANDRA_VERSION="$$SCYLLA_VERSION_RESOLVED" CCM_IS_SCYLLA=true $(SBT_CMD) test it:test
+
+compile: resolve-scala-version
+	@JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS)" $(SBT_CMD) compile Test/compile IntegrationTest/compile
 
 test-unit: resolve-scala-version
 	@JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS)" $(SBT_CMD) test


### PR DESCRIPTION
## Summary

- **Compile once, test many**: Added a shared `compile` job that compiles all modules (including test sources) and caches the output. Both `lint` and `test` jobs restore this cache, avoiding redundant ~5-10 min compilation per matrix entry.
- **New `make compile` target**: Compiles main, test, and integration test sources in one go.

## Related issues/PRs

- #42 — Avoid setting up unused Java versions (separate issue)
- #43 — Improve CCM caching and pin get-version tool (separate issue)
- #45 — Increase test parallelism (separate PR)

## Test plan

- [x] Verify compile job runs and caches classes successfully
- [x] Verify lint job restores compiled classes and runs without recompiling
- [x] Verify test jobs restore compiled classes and skip compilation phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)