### PR TITLE
CI: Increase test parallelism from 1 to 2

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -96,7 +96,7 @@ jobs:
       CASSANDRA_VERSION: ${{ matrix.db-type == 'cassandra' && matrix.db-version || '' }}
       SCYLLA_VERSION: ${{ matrix.db-type == 'scylla' && matrix.db-version || '' }}
       SCALA_VERSION: ${{ matrix.scala }}
-      TEST_PARALLEL_TASKS: 1
+      TEST_PARALLEL_TASKS: 2
       PUBLISH_VERSION: test
 
     steps:


### PR DESCRIPTION
## Summary

- Bumps `TEST_PARALLEL_TASKS` from `1` to `2` for integration tests

GitHub runners have ~7GB RAM. The auto-detection logic in `Testing.scala` calculates `(7168 - 1550) / 2560 = 2` parallel tasks, so this matches what the runner can handle.

## Test plan

- [x] Verify integration tests pass with 2 parallel test groups
- [x] Monitor for OOM issues on GitHub runners