### PR TITLE
Make AsyncExecutor maxRetries configurable

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -75,6 +75,7 @@ case class CassandraConnectorConf(
   remoteConnectionsPerExecutor: Option[Int] = CassandraConnectorConf.RemoteConnectionsPerExecutorParam.default,
   compression: String = CassandraConnectorConf.CompressionParam.default,
   queryRetryCount: Int = CassandraConnectorConf.QueryRetryParam.default,
+  queryRetryMaxRetries: Int = CassandraConnectorConf.QueryRetryMaxRetriesParam.default,
   connectTimeoutMillis: Int = CassandraConnectorConf.ConnectionTimeoutParam.default,
   readTimeoutMillis: Int = CassandraConnectorConf.ReadTimeoutParam.default,
   connectionFactory: CassandraConnectionFactory = DefaultConnectionFactory,
@@ -235,6 +236,15 @@ object CassandraConnectorConf extends Logging {
       """Number of times to retry a timed-out query
         |Setting this to -1 means unlimited retries
       """.stripMargin)
+
+  val QueryRetryMaxRetriesParam = ConfigParameter[Int](
+    name = "spark.cassandra.query.retry.maxRetries",
+    section = ReferenceSection,
+    default = 10,
+    description =
+      """Maximum number of retries for a failed query due to transient errors
+        |(NodeUnavailableException, BusyConnectionException, OverloadedException).
+        |Set to 0 to disable retries.""".stripMargin)
 
   val ReadTimeoutParam = ConfigParameter[Int](
     name = "spark.cassandra.read.timeoutMS",
@@ -437,6 +447,7 @@ object CassandraConnectorConf extends Logging {
     val localConnections = conf.getOption(LocalConnectionsPerExecutorParam.name).map(_.toInt)
     val remoteConnections = conf.getOption(RemoteConnectionsPerExecutorParam.name).map(_.toInt)
     val queryRetryCount = conf.getInt(QueryRetryParam.name, QueryRetryParam.default)
+    val queryRetryMaxRetries = conf.getInt(QueryRetryMaxRetriesParam.name, QueryRetryMaxRetriesParam.default)
     val connectTimeout = conf.getInt(ConnectionTimeoutParam.name, ConnectionTimeoutParam.default)
     val readTimeout = conf.getInt(ReadTimeoutParam.name, ReadTimeoutParam.default)
     val quietPeriodBeforeClose = conf.getInt(QuietPeriodBeforeCloseParam.name, QuietPeriodBeforeCloseParam.default)
@@ -457,6 +468,7 @@ object CassandraConnectorConf extends Logging {
       remoteConnectionsPerExecutor = remoteConnections,
       compression = compression,
       queryRetryCount = queryRetryCount,
+      queryRetryMaxRetries = queryRetryMaxRetries,
       connectTimeoutMillis = connectTimeout,
       readTimeoutMillis = readTimeout,
       connectionFactory = connectionFactory,

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraInJoinReaderFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraInJoinReaderFactory.scala
@@ -76,7 +76,7 @@ abstract class CassandraBaseInJoinReader(
   protected val bsb = JoinHelper.getKeyBuilderStatementBuilder(session, rowWriter, preparedStatement, cqlQueryParts.whereClause)
   protected val rowMetadata = JoinHelper.getCassandraRowMetadata(session, preparedStatement, cqlQueryParts.selectedColumnRefs)
 
-  protected val queryExecutor = QueryExecutor(session, readConf.parallelismLevel, None, None)
+  protected val queryExecutor = QueryExecutor(session, readConf.parallelismLevel, None, None, connector.conf)
   protected val maybeRateLimit = JoinHelper.maybeRateLimit(readConf)
   protected val requestsPerSecondRateLimiter = JoinHelper.requestsPerSecondRateLimiter(readConf)
 

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -143,7 +143,7 @@ class CassandraJoinRDD[L, R] (
     metricsUpdater: InputMetricsUpdater
   ): Iterator[(L, R)] = {
 
-    val queryExecutor = QueryExecutor(session, readConf.parallelismLevel, None, None)
+    val queryExecutor = QueryExecutor(session, readConf.parallelismLevel, None, None, connector.conf)
 
     def pairWithRight(left: L): SettableFuture[Iterator[(L, R)]] = {
       val resultFuture = SettableFuture.create[Iterator[(L, R)]]

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -170,7 +170,7 @@ class CassandraLeftJoinRDD[L, R] (
   ): Iterator[(L, Option[R])] = {
     import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
 
-    val queryExecutor = QueryExecutor(session, readConf.parallelismLevel, None, None)
+    val queryExecutor = QueryExecutor(session, readConf.parallelismLevel, None, None, connector.conf)
 
     def pairWithRight(left: L): SettableFuture[Iterator[(L, Option[R])]] = {
       val resultFuture = SettableFuture.create[Iterator[(L, Option[R])]]

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/QueryExecutor.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/QueryExecutor.scala
@@ -20,25 +20,25 @@ package com.datastax.spark.connector.writer
 
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet
+import com.datastax.spark.connector.cql.CassandraConnectorConf
 import com.datastax.spark.connector.writer.AsyncExecutor.Handler
 
 class QueryExecutor(
  session: CqlSession,
  maxConcurrentQueries: Int,
  successHandler: Option[Handler[RichStatement]],
- failureHandler: Option[Handler[RichStatement]])
+ failureHandler: Option[Handler[RichStatement]],
+ maxRetries: Int = CassandraConnectorConf.QueryRetryMaxRetriesParam.default)
 
   extends AsyncExecutor[RichStatement, AsyncResultSet](
     stmt => session.executeAsync(stmt.stmt),
     maxConcurrentQueries,
     successHandler,
-    failureHandler)
+    failureHandler,
+    maxRetries)
 
 object QueryExecutor {
 
-  /**
-    * Builds a query executor whose max requests per connection is limited to the MaxRequests per Connection
-    */
   def apply(
     session: CqlSession,
     maxConcurrentQueries: Int,
@@ -46,5 +46,20 @@ object QueryExecutor {
     failureHandler: Option[Handler[RichStatement]]): QueryExecutor = {
 
     new QueryExecutor(session, maxConcurrentQueries, successHandler, failureHandler)
+  }
+
+  def apply(
+    session: CqlSession,
+    maxConcurrentQueries: Int,
+    successHandler: Option[Handler[RichStatement]],
+    failureHandler: Option[Handler[RichStatement]],
+    connectorConf: CassandraConnectorConf): QueryExecutor = {
+
+    new QueryExecutor(
+      session,
+      maxConcurrentQueries,
+      successHandler,
+      failureHandler,
+      maxRetries = connectorConf.queryRetryMaxRetries)
   }
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -305,7 +305,9 @@ case class AsyncStatementWriter[T](
   private val keyspaceName: String = tableDef.keyspaceName
   private val tableName: String = tableDef.tableName
 
-  private lazy val queryExecutor = new QueryExecutor(session, writeConf.parallelismLevel, successHandler, failureHandler)
+  private lazy val queryExecutor = new QueryExecutor(
+    session, writeConf.parallelismLevel, successHandler, failureHandler,
+    maxRetries = connector.conf.queryRetryMaxRetries)
 
   def write(record: T): Unit= {
     groupingBatchBuilderBase.batchRecord(record).foreach{ stmt =>


### PR DESCRIPTION
## Summary

- Add `spark.cassandra.query.retry.maxRetries` config parameter (default: 10) to `CassandraConnectorConf`
- Thread it through `QueryExecutor` to all call sites: `TableWriter`, `CassandraJoinRDD`, `CassandraLeftJoinRDD`, `CassandraInJoinReaderFactory`

## Test plan

- [x] All 320 unit tests pass
- [ ] Integration tests on CI