### PR TITLE
Fix clustering order not propagated from driver metadata

### DIFF
--- a/driver/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
+++ b/driver/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
@@ -330,7 +330,13 @@ object Schema extends Logging {
 
   private def fetchClusteringColumns(table: RelationMetadata): Seq[ColumnDef] = {
     for ((column, index) <- table.getClusteringColumns.asScala.toSeq.zipWithIndex) yield {
-      ColumnDef(column._1, ClusteringColumn(index))
+      val sortDirection = column._2 match {
+        case com.datastax.oss.driver.api.core.metadata.schema.ClusteringOrder.DESC =>
+          ClusteringColumn.Descending
+        case _ =>
+          ClusteringColumn.Ascending
+      }
+      ColumnDef(column._1, ClusteringColumn(index, sortDirection))
     }
   }
 


### PR DESCRIPTION
## Summary
- `Schema.fetchClusteringColumns` was ignoring the `ClusteringOrder` from the Java driver metadata, defaulting all clustering columns to ASC
- Map `ClusteringOrder.DESC` to `ClusteringColumn.Descending` so the connector correctly reflects DESC clustering columns

## Test plan
- Existing unit tests in `TableDefSpec` cover clustering column serialization
- Integration tests `CassandraDataFrameSpec` and `CassandraCatalogTableSpec` verify correct clustering order on Cassandra