### PR TITLE
Remove notScylla skips for clustering order tests

### DIFF
--- a/connector/src/it/scala/com/datastax/spark/connector/datasource/CassandraCatalogTableSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/datasource/CassandraCatalogTableSpec.scala
@@ -91,7 +91,7 @@ class CassandraCatalogTableSpec extends CassandraCatalogSpecBase {
     normalizedActual should contain theSameElementsAs normalizedExpected
   }
 
-  it should "create a table with multiple partition keys and clustering keys" in notScylla("scylladb/spark-scylladb-connector#25: Clustering order on Scylla always reported as ASC") {
+  it should "create a table with multiple partition keys and clustering keys" in {
     createDefaultKs()
     spark.sql(
       s"""CREATE TABLE $defaultKs.$testTable (
@@ -278,7 +278,7 @@ class CassandraCatalogTableSpec extends CassandraCatalogSpecBase {
     afterDetailedTableInformationMap.get("Name") should be(Some("testTable"))
   }
 
-  it should "describe table properties" in notScylla("scylladb/spark-scylladb-connector#25: Clustering order on Scylla always reported as ASC") {
+  it should "describe table properties" in {
     createDefaultKs()
     spark.sql(
       s"""CREATE TABLE $defaultKs.$testTable (

--- a/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSpec.scala
@@ -203,7 +203,7 @@ class CassandraDataFrameSpec extends SparkCassandraITFlatSpecBase with DefaultCl
 
   }
 
-  it should " be able to create a customized C* schema from a table" in notScylla("scylladb/spark-scylladb-connector#25: Clustering order on Scylla always reported as ASC") {
+  it should " be able to create a customized C* schema from a table" in {
     val df = spark
       .read
       .format("org.apache.spark.sql.cassandra")


### PR DESCRIPTION
## Summary
- Remove `notScylla()` guards from 3 integration tests that were skipped due to scylladb/spark-scylladb-connector#25
- The underlying Scylla bug (DESC clustering order reported as ASC in system_schema.columns) has been fixed in modern Scylla versions
- Verified on Scylla 2025.2.5 that clustering_order is correctly reported

## Affected tests
- `CassandraDataFrameSpec: should be able to create a customized C* schema from a table`
- `CassandraCatalogTableSpec: should create a table with multiple partition keys and clustering keys`
- `CassandraCatalogTableSpec: should describe table properties`

## Test plan
- Run integration tests with Scylla to confirm the previously-skipped tests now pass