### PR TITLE
cicd: fix release workflow push on detached HEAD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,5 +86,6 @@ jobs:
       - name: Push changes to SCM
         if: ${{ inputs.dry-run == false && inputs.target-tag == 'scylla-4.x' }}
         run: |
+          git checkout scylla-4.x
           git status && git log -3
           git push origin --follow-tags -v


### PR DESCRIPTION
## Summary
- The `make release` target checks out the release tag (`v4.1.0`), leaving git in detached HEAD state
- The subsequent "Push changes to SCM" step fails because `git push` doesn't know which branch to push
- Fix by checking out `scylla-4.x` before pushing

Fixes https://github.com/scylladb/spark-scylladb-connector/actions/runs/22368033253/job/64739149185