### PR TITLE
cicd: add secret masking in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,9 @@ jobs:
       - name: Import GPG key
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
-        run: echo "$PGP_SECRET" | base64 --decode | gpg --import --no-tty --batch --yes
+        run: |
+          echo "::add-mask::${PGP_SECRET}"
+          echo "$PGP_SECRET" | base64 --decode | gpg --import --no-tty --batch --yes
 
       - name: Configure Git user
         run: |
@@ -65,7 +67,11 @@ jobs:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_TOKEN_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}
-        run: make release
+        run: |
+          echo "::add-mask::${PGP_PASSPHRASE}"
+          echo "::add-mask::${SONATYPE_USERNAME}"
+          echo "::add-mask::${SONATYPE_PASSWORD}"
+          make release
 
       - name: Perform release dry-run
         if: inputs.dry-run == true
@@ -74,7 +80,11 @@ jobs:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_TOKEN_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}
-        run: make release-dry-run
+        run: |
+          echo "::add-mask::${PGP_PASSPHRASE}"
+          echo "::add-mask::${SONATYPE_USERNAME}"
+          echo "::add-mask::${SONATYPE_PASSWORD}"
+          make release-dry-run
 
       - name: Upload release logs
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,5 +86,6 @@ jobs:
       - name: Push changes to SCM
         if: ${{ inputs.dry-run == false && inputs.target-tag == 'scylla-4.x' }}
         run: |
+          git checkout scylla-4.x
           git status && git log -3
           git push origin --follow-tags -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,5 @@ jobs:
       - name: Push changes to SCM
         if: ${{ inputs.dry-run == false && inputs.target-tag == 'scylla-4.x' }}
         run: |
-          git checkout scylla-4.x
           git status && git log -3
           git push origin --follow-tags -v


### PR DESCRIPTION
## Summary
- Adds explicit `::add-mask::` directives for secrets in the release workflow
- Masks PGP_SECRET before GPG import to prevent leaks on step failure
- Masks PGP_PASSPHRASE and Sonatype credentials before release commands

## Test plan
- [x] Trigger a dry-run release and verify secrets are masked in logs