### PR TITLE
cicd: add dedicated unit test job

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -122,6 +122,58 @@ jobs:
       - name: Run scalastyle
         run: make lint
 
+  unit-test:
+    name: "Unit Tests"
+    needs: compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Restore SBT cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.cache/coursier
+          key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/*.scala') }}
+          restore-keys: |
+            sbt-${{ runner.os }}-
+
+      - name: Restore Maven cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/*.scala') }}
+          restore-keys: |
+            maven-${{ runner.os }}-
+
+      - name: Restore compiled classes
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            **/target/scala-*
+            **/target/streams
+          key: compiled-${{ runner.os }}-${{ github.sha }}-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/*.scala') }}
+
+      - name: Run unit tests
+        run: make test-unit
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v6
+        if: always()
+        with:
+          report_paths: '**/target/test-reports/*.xml'
+          check_name: "Unit Test Report"
+          annotate_only: true
+          detailed_summary: true
+
   prepare:
     name: "Prepare test matrix"
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,5 +86,6 @@ jobs:
       - name: Push changes to SCM
         if: ${{ inputs.dry-run == false && inputs.target-tag == 'scylla-4.x' }}
         run: |
+          git checkout scylla-4.x
           git status && git log -3
           git push origin --follow-tags -v


### PR DESCRIPTION
## Summary
- Adds a dedicated unit test job to the CI workflow that runs after compilation
- Unit tests run independently from integration tests for faster feedback
- Includes JUnit report publishing for test result visibility in PRs

## Test plan
- [x] Verify the unit test job runs successfully in this PR's CI
- [x] Confirm test reports appear as PR annotations