### PR TITLE
cicd: add test coverage reporting with sbt-scoverage

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -174,6 +174,53 @@ jobs:
           annotate_only: true
           detailed_summary: true
 
+  coverage:
+    name: "Test Coverage"
+    needs: compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Restore SBT cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.cache/coursier
+          key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/*.scala') }}
+          restore-keys: |
+            sbt-${{ runner.os }}-
+
+      - name: Restore Maven cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/*.scala') }}
+          restore-keys: |
+            maven-${{ runner.os }}-
+
+      - name: Run tests with coverage
+        env:
+          SCALA_VERSION: ${{ inputs.scala-versions || '2-LATEST' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make test-coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: |
+            **/target/scala-*/scoverage-report/
+            **/target/scala-*/coverage-report/
+
   prepare:
     name: "Prepare test matrix"
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := bash
 .ONESHELL:
 .SHELLFLAGS := -ec
 
-.PHONY: help sbt clean compile test-unit test-integration-cassandra test-integration-scylla \
+.PHONY: help sbt clean compile test-unit test-coverage test-integration-cassandra test-integration-scylla \
         resolve-cassandra-version resolve-scylla-version resolve-scala-version \
         download-cassandra download-scylla install-cassandra-ccm install-scylla-ccm \
         generate-test-matrix lint lint-fix generate-test-certs \
@@ -283,6 +283,9 @@ test-integration-scylla: resolve-scala-version resolve-scylla-version generate-t
 
 compile: resolve-scala-version ## Compile all modules
 	@JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS)" $(SBT_CMD) compile Test/compile IntegrationTest/compile
+
+test-coverage: resolve-scala-version ## Run unit tests with coverage
+	@COVERAGE=true JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS)" $(SBT_CMD) coverage test coverageReport
 
 test-unit: resolve-scala-version ## Run unit tests
 	@JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS)" $(SBT_CMD) test

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,9 @@ ThisBuild / scalaVersion := scala213
 ThisBuild / scalacOptions ++= Seq("-release:17")
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
+ThisBuild / coverageEnabled := sys.env.getOrElse("COVERAGE", "false").toBoolean
+// Allow scoverage's scala-library to be newer than scalaVersion (SIP-51 check)
+ThisBuild / allowUnsafeScalaLibUpgrade := (ThisBuild / coverageEnabled).value
 
 // Publishing Info
 ThisBuild / homepage := Some(url("https://github.com/scylladb/spark-scylladb-connector"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,7 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
 
 addSbtPlugin("com.beautiful-scala" % "sbt-scalastyle" % "1.5.1")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
+
+libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always


### PR DESCRIPTION
## Summary
- Adds sbt-scoverage plugin for Scala test coverage measurement
- Coverage is opt-in via COVERAGE=true environment variable (disabled by default to avoid impacting normal builds)
- Adds `make test-coverage` target
- Adds a coverage job to the CI workflow that uploads HTML reports as artifacts

## Test plan
- [x] Verify `make test-coverage` runs locally
- [x] Check coverage report artifact is uploaded in CI