### PR TITLE
cicd: add weekly dependency update check workflow

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -1,0 +1,33 @@
+name: Dependency Updates
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+jobs:
+  check-updates:
+    name: Check for dependency updates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Restore SBT cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.cache/coursier
+          key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/*.scala') }}
+          restore-keys: |
+            sbt-${{ runner.os }}-
+
+      - name: Check for dependency updates
+        run: ./sbt/sbt dependencyUpdates


### PR DESCRIPTION
## Summary
- Adds a weekly CI workflow that runs `sbt dependencyUpdates` to check for outdated dependencies
- Uses the already-installed `sbt-updates` plugin which was previously not wired into CI
- Runs every Monday at 8:00 UTC and can be triggered manually

## Test plan
- [x] Trigger the workflow manually and verify it reports dependency versions