### PR TITLE
cicd: modernize pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,28 +1,15 @@
-# Description
+## Description
 
-## How did the Spark Cassandra Connector Work or Not Work Before this Patch
+What does this PR do? Why is it needed?
 
-Describe the problem, or state of the project that this patch fixes. Explain
-why this is a problem if this isn't obvious.
+## Test plan
 
-Example: 
-  "When I read from tables with 3 INTS I get a ThreeIntException(). This is a problem because I often want to read from a table with three integers."
+How was this tested? Any new tests added?
 
-## General Design of the patch
+## Checklist
 
-How the fix is accomplished, were new parameters or classes added? Why did you
-pursue this particular fix?
-
-Example: "I removed the incorrect assertion which would throw the ThreeIntException. This exception was incorrectly added and the assertion is not actually needed."
-
-Fixes: [Put JIRA Reference HERE](https://issues.apache.org/jira/projects/CASSANALYTICS)
-
-# How Has This Been Tested?
-
-Almost all changes and especially bug fixes will require a test to be added to either the integration or Unit Tests. Any tests added will be automatically run on travis when the pull request is pushed to github. Be sure to run suites locally as well.
-
-# Checklist:
-
-- [ ] I have a ticket in the [JIRA](https://issues.apache.org/jira/projects/CASSANALYTICS)
 - [ ] I have performed a self-review of my own code
-- [ ] Locally all tests pass (make sure tests fail without your patch)
+- [ ] All unit tests pass (`make test-unit`)
+- [ ] Linting passes (`make lint`)
+- [ ] Integration test results reviewed (if applicable)
+- [ ] No new compiler warnings introduced


### PR DESCRIPTION
## Summary
- Modernizes the PR template for the ScyllaDB fork
- Removes references to Apache JIRA and Travis CI from the upstream project
- Adds CI-relevant checklist items: lint passes, no new warnings, integration test review

## Test plan
- [x] Verify the new template renders correctly when opening a PR