### PR TITLE
docs: regenerate reference.md to fix DocCheck integration test

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -339,7 +339,7 @@ columname will be used to set the writetime for that row.</td>
 <tr>
   <td><code>spark.cassandra.input.consistency.level</code></td>
   <td>LOCAL_ONE</td>
-  <td>Consistency level to use when reading	</td>
+  <td>Consistency level to use when reading</td>
 </tr>
 <tr>
   <td><code>spark.cassandra.input.fetch.sizeInRows</code></td>


### PR DESCRIPTION
## Summary
- Remove stale tab character in `doc/reference.md` for the `spark.cassandra.input.consistency.level` parameter description
- This tab was left behind when the scalastyle lint pipeline was integrated (commit 13f900b3), which cleaned up whitespace in source code but did not regenerate the reference doc
- Fixes `DocCheck` integration test failure affecting all integration test jobs on `scylla-4.x`

## Test plan
- [x] Verify `DocCheck` integration test passes (the test compares `doc/reference.md` against dynamically generated output from source code descriptions)
- [x] All other CI checks remain green