### PR TITLE
fix: cache prepared statement across token ranges in partition scans

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraScanPartitionReaderFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraScanPartitionReaderFactory.scala
@@ -122,8 +122,20 @@ abstract class CassandraPartitionReaderBase
   than all of the rows returned by the previous query have been consumed.
   */
   protected def getIterator(): Iterator[InternalRow] = {
+    // Prepare the scan statement once and reuse across all token ranges in this partition.
+    // The CQL template is identical for every range — only bind values differ.
+    val preparedStmt = tokenRanges.headOption.map { firstRange =>
+      val (cql, _) = ScanHelper.tokenRangeToCqlQuery(firstRange, tableDef, queryParts)
+      ScanHelper.prepareScanStatement(scanner.getSession(), cql)
+    }
+
     tokenRanges.iterator.flatMap { range =>
-      val scanResult = ScanHelper.fetchTokenRange(scanner, tableDef, queryParts, range, readConf.consistencyLevel, readConf.fetchSizeInRows)
+      val scanResult = preparedStmt match {
+        case Some(ps) =>
+          ScanHelper.fetchTokenRange(scanner, tableDef, queryParts, range, readConf.consistencyLevel, readConf.fetchSizeInRows, ps)
+        case None =>
+          ScanHelper.fetchTokenRange(scanner, tableDef, queryParts, range, readConf.consistencyLevel, readConf.fetchSizeInRows)
+      }
       val meta = scanResult.metadata
       scanResult.rows.map(rowReader.read(_, meta))
     }

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraScanPartitionReaderFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraScanPartitionReaderFactory.scala
@@ -124,7 +124,8 @@ abstract class CassandraPartitionReaderBase
   protected def getIterator(): Iterator[InternalRow] = {
     // Prepare the scan statement once and reuse across all token ranges in this partition.
     // The CQL template is identical for every range — only bind values differ.
-    val preparedStmt = tokenRanges.headOption.map { firstRange =>
+    // Must be lazy because `scanner` is initialized after `getIterator()` is called.
+    lazy val preparedStmt = tokenRanges.headOption.map { firstRange =>
       val (cql, _) = ScanHelper.tokenRangeToCqlQuery(firstRange, tableDef, queryParts)
       ScanHelper.prepareScanStatement(scanner.getSession(), cql)
     }

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/ScanHelper.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/ScanHelper.scala
@@ -20,7 +20,7 @@ package com.datastax.spark.connector.datasource
 
 import java.io.IOException
 import com.datastax.oss.driver.api.core.CqlIdentifier._
-import com.datastax.oss.driver.api.core.cql.BoundStatement
+import com.datastax.oss.driver.api.core.cql.{BoundStatement, PreparedStatement}
 import com.datastax.oss.driver.api.core.{ConsistencyLevel, CqlSession}
 import com.datastax.spark.connector.cql.{CassandraConnector, ScanResult, Scanner, TableDef}
 import com.datastax.spark.connector.rdd.CassandraLimit.limitToClause
@@ -100,6 +100,36 @@ object ScanHelper extends Logging {
     scanResult
   }
 
+  /**
+   * Variant of fetchTokenRange that accepts a pre-prepared statement to avoid
+   * re-preparing the same CQL for every token range within a partition.
+   */
+  def fetchTokenRange(
+    scanner: Scanner,
+    tableDef: TableDef,
+    queryParts: CqlQueryParts,
+    range: CqlTokenRange[_, _],
+    consistencyLevel: ConsistencyLevel,
+    fetchSize: Int,
+    preparedStatement: PreparedStatement): ScanResult = {
+
+    val (_, values) = tokenRangeToCqlQuery(range, tableDef, queryParts)
+
+    logDebug(
+      s"Fetching data for range ${range.cql(partitionKeyStr(tableDef))} " +
+        s"with params ${values.mkString("[", ",", "]")}")
+
+    val stmt = bindScanStatement(preparedStatement, values: _*)
+      .setConsistencyLevel(consistencyLevel)
+      .setPageSize(fetchSize)
+      .setRoutingToken(range.range.startNativeToken())
+
+    val scanResult = scanner.scan(stmt)
+    logDebug(s"Row iterator for range ${range.cql(partitionKeyStr(tableDef))} obtained successfully.")
+
+    scanResult
+  }
+
   def partitionKeyStr(tableDef: TableDef) = {
     tableDef.partitionKey.map(_.columnName).map(quote).mkString(", ")
   }
@@ -160,18 +190,45 @@ object ScanHelper extends Logging {
   def prepareScanStatement(session: CqlSession, cql: String, values: Any*): BoundStatement = {
     try {
       val stmt = session.prepare(cql)
-      val converters = stmt.getVariableDefinitions.asScala
+      bindScanStatement(stmt, values: _*)
+    }
+    catch {
+      case t: Throwable =>
+        throw new IOException(s"Exception during preparation of $cql: ${t.getMessage}", t)
+    }
+  }
+
+  /**
+   * Prepare a CQL statement without binding any values.
+   * Use with [[bindScanStatement]] to prepare once and bind per token range.
+   */
+  def prepareScanStatement(session: CqlSession, cql: String): PreparedStatement = {
+    try {
+      session.prepare(cql)
+    }
+    catch {
+      case t: Throwable =>
+        throw new IOException(s"Exception during preparation of $cql: ${t.getMessage}", t)
+    }
+  }
+
+  /**
+   * Bind values to an already-prepared statement.
+   */
+  def bindScanStatement(preparedStatement: PreparedStatement, values: Any*): BoundStatement = {
+    try {
+      val converters = preparedStatement.getVariableDefinitions.asScala
         .map(v => ColumnType.converterToCassandra(v.getType))
         .toArray
       val convertedValues =
         for ((value, converter) <- values zip converters)
           yield converter.convert(value)
-      stmt.bind(convertedValues: _*)
+      preparedStatement.bind(convertedValues: _*)
         .setIdempotent(true)
     }
     catch {
       case t: Throwable =>
-        throw new IOException(s"Exception during preparation of $cql: ${t.getMessage}", t)
+        throw new IOException(s"Exception during binding of prepared statement: ${t.getMessage}", t)
     }
   }
 

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
@@ -322,9 +322,21 @@ class CassandraTableScanRDD[R] private[connector](
     // Iterator flatMap trick flattens the iterator-of-iterator structure into a single iterator.
     // flatMap on iterator is lazy, therefore a query for the next token range is executed not earlier
     // than all of the rows returned by the previous query have been consumed
+    // Prepare the scan statement once and reuse across all token ranges in this partition.
+    // The CQL template is identical for every range — only bind values differ.
+    val preparedStmt = tokenRanges.headOption.map { firstRange =>
+      val (cql, _) = ScanHelper.tokenRangeToCqlQuery(firstRange, tableDef, queryParts)
+      ScanHelper.prepareScanStatement(scanner.getSession(), cql)
+    }
+
     val rowIterator = tokenRanges.iterator.flatMap { range =>
       try {
-        val scanResult = ScanHelper.fetchTokenRange(scanner, tableDef, queryParts, range, consistencyLevel, fetchSize)
+        val scanResult = preparedStmt match {
+          case Some(ps) =>
+            ScanHelper.fetchTokenRange(scanner, tableDef, queryParts, range, consistencyLevel, fetchSize, ps)
+          case None =>
+            ScanHelper.fetchTokenRange(scanner, tableDef, queryParts, range, consistencyLevel, fetchSize)
+        }
         val iteratorWithMetrics = scanResult.rows.map(metricsUpdater.updateMetrics)
         val result = iteratorWithMetrics.map(rowReader.read(_, scanResult.metadata))
         result


### PR DESCRIPTION
## Summary

- **Problem**: `session.prepare(cql)` was called for every token range within a partition in `ScanHelper.fetchTokenRange`. Since the CQL template is identical across all ranges (only bind values differ), this caused redundant prepare round-trips for partitions with many vnode ranges.
- **Fix**: Split prepare and bind steps. The prepared statement is now created once before iterating over token ranges, then only bound with new values per range.
- Updated both call sites: `CassandraTableScanRDD.compute` and `CassandraPartitionReaderBase.getIterator`.

Closes: https://github.com/scylladb/spark-scylladb-connector/issues/72
## Changes

- `ScanHelper`: Added `prepareScanStatement(session, cql)` overload returning `PreparedStatement`, `bindScanStatement` for binding values to an existing prepared statement, and a `fetchTokenRange` overload accepting a pre-prepared `PreparedStatement`.
- `CassandraTableScanRDD`: Prepare once before the token range loop and pass the prepared statement to `fetchTokenRange`.
- `CassandraScanPartitionReaderFactory`: Same pattern — prepare once in `getIterator` before the loop.

## Test plan

- [x] All 320 unit tests pass
- [x] Linting passes (scalafix + scalastyle)
- [x] Integration tests (require CCM cluster)