### PR TITLE
fix: replace blocking Thread.sleep with ScheduledExecutorService in AsyncExecutor retries

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala
@@ -18,7 +18,7 @@
 
 package com.datastax.spark.connector.writer
 
-import java.util.concurrent.{CompletableFuture, CompletionStage, Semaphore}
+import java.util.concurrent.{CompletableFuture, CompletionStage, Executors, ScheduledExecutorService, Semaphore, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.BiConsumer
 import com.datastax.spark.connector.util.Logging
@@ -95,8 +95,7 @@ class AsyncExecutor[T, R](asyncAction: T => CompletionStage[R], maxConcurrentTas
             if (attempt <= maxRetries) {
               val delayMs = math.min(BaseRetryDelayMs * (1L << math.min(attempt - 1, MaxBackoffShift)), MaxRetryDelayMs)
               logTrace(s"${throwable.getClass.getSimpleName} ... Retrying (attempt $attempt/$maxRetries, backoff ${delayMs}ms)")
-              Thread.sleep(delayMs)
-              tryFuture()
+              RetryScheduler.schedule(new Runnable { def run(): Unit = tryFuture() }, delayMs, TimeUnit.MILLISECONDS)
             } else {
               logError(s"Failed to execute after $maxRetries retries: " + task, throwable)
               latestException = Some(throwable)
@@ -146,4 +145,11 @@ object AsyncExecutor {
   val BaseRetryDelayMs: Long = 100
   val MaxRetryDelayMs: Long = 5000
   val MaxBackoffShift: Int = 6 // caps the bit shift to avoid overflow: 100 * 2^6 = 6400 -> clamped to 5000
+
+  private[writer] val RetryScheduler: ScheduledExecutorService =
+    Executors.newScheduledThreadPool(1, (r: Runnable) => {
+      val t = new Thread(r, "async-executor-retry-scheduler")
+      t.setDaemon(true)
+      t
+    })
 }


### PR DESCRIPTION
## Summary

- Replace `Thread.sleep(delayMs)` in `AsyncExecutor.onFailure` with a non-blocking `ScheduledExecutorService.schedule()` call
- Add a shared daemon-threaded `RetryScheduler` in the `AsyncExecutor` companion object
- Preserves existing exponential backoff behavior (100ms base, 5s max, up to 10 retries)

Closes: https://github.com/scylladb/spark-scylladb-connector/issues/71
## Problem

The `onFailure` callback in `AsyncExecutor` runs on the Cassandra/ScyllaDB driver's Netty I/O thread. Calling `Thread.sleep(delayMs)` (up to 5 seconds) blocks that I/O thread, stalling all other async operations that share it. Under load with retryable errors, this can cascade into widespread latency spikes.

## Fix

Use a `ScheduledExecutorService` with a single daemon thread to schedule retries after the backoff delay. The callback thread returns immediately, keeping the driver's I/O threads free.

## Test plan

- [x] Verify `./sbt/sbt connector/compile` succeeds (confirmed locally)
- [x] Existing unit tests pass
- [x] Integration tests with Cassandra/ScyllaDB validate retry behavior under load