### PR TITLE
Batch join lookups using CQL IN clauses for clustering keys

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/JoinHelper.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/JoinHelper.scala
@@ -20,17 +20,85 @@ package com.datastax.spark.connector.datasource
 
 import java.util.concurrent.Future
 
-import com.datastax.oss.driver.api.core.cql.{PreparedStatement, Row, SimpleStatement}
+import com.datastax.oss.driver.api.core.`type`.codec.registry.CodecRegistry
+import com.datastax.oss.driver.api.core.cql.{BoundStatement, PreparedStatement, Row, SimpleStatement}
 import com.datastax.oss.driver.api.core.{ConsistencyLevel, CqlIdentifier, CqlSession}
 import com.datastax.spark.connector.cql.{TableDef, getRowBinarySize}
 import com.datastax.spark.connector.datasource.ScanHelper.CqlQueryParts
 import com.datastax.spark.connector.rdd.{CassandraLimit, CqlWhereClause, ReadConf}
+import com.datastax.spark.connector.types.ColumnType
 import com.datastax.spark.connector.util.CqlWhereParser.{EqPredicate, InListPredicate, InPredicate, RangePredicate}
-import com.datastax.spark.connector.util.{CqlWhereParser, Logging}
+import com.datastax.spark.connector.util.{CodecRegistryUtil, CqlWhereParser, Logging}
 import com.datastax.spark.connector.writer.{BoundStatementBuilder, RateLimiter, RowWriter}
 import com.datastax.spark.connector.{AllColumns, CassandraRowMetadata, ColumnRef, ColumnSelector, PartitionKeyColumns, PrimaryKeyColumns, SomeColumns}
 
+import scala.collection.mutable
+
 object JoinHelper extends Logging {
+
+  /**
+   * Determines which join columns are partition key columns and which are clustering columns.
+   * Returns (partitionKeyJoinColumns, clusteringJoinColumns) in table definition order.
+   */
+  def splitJoinColumns(tableDef: TableDef, joinColumnNames: Seq[ColumnRef]): (Seq[ColumnRef], Seq[ColumnRef]) = {
+    val partitionKeyNames = tableDef.partitionKey.map(_.columnName).toSet
+    val clusteringNames = tableDef.clusteringColumns.map(_.columnName).toSet
+    val joinColNames = joinColumnNames.map(_.columnName).toSet
+
+    val pkCols = tableDef.partitionKey
+      .filter(c => joinColNames.contains(c.columnName))
+      .map(c => joinColumnNames.find(_.columnName == c.columnName).get)
+    val ckCols = tableDef.clusteringColumns
+      .filter(c => joinColNames.contains(c.columnName))
+      .map(c => joinColumnNames.find(_.columnName == c.columnName).get)
+
+    (pkCols, ckCols)
+  }
+
+  /**
+   * Generates a CQL query string with IN clause for the last clustering column in the join.
+   * Used for batching multiple left-side rows that share the same partition key.
+   *
+   * @param inClauseSize number of placeholders in the IN clause
+   */
+  def getJoinInQueryString(
+    tableDef: TableDef,
+    joinColumns: Seq[ColumnRef],
+    queryParts: CqlQueryParts,
+    inClauseSize: Int): String = {
+
+    val (pkCols, ckCols) = splitJoinColumns(tableDef, joinColumns)
+    require(ckCols.nonEmpty, "IN clause batching requires at least one clustering column in the join")
+    require(inClauseSize >= 1, s"IN clause size must be >= 1, got $inClauseSize")
+
+    val columns = queryParts.selectedColumnRefs.map(_.cql).mkString(", ")
+    val limitClause = CassandraLimit.limitToClause(queryParts.limitClause)
+    val orderBy = queryParts.clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
+
+    // Partition key columns use = :name
+    val pkWhere = pkCols.map(c =>
+      s"${CqlIdentifier.fromInternal(c.columnName).asCql(true)} = :${c.columnName}")
+
+    // All clustering columns except the last use = :name
+    val ckEqWhere = ckCols.init.map(c =>
+      s"${CqlIdentifier.fromInternal(c.columnName).asCql(true)} = :${c.columnName}")
+
+    // Last clustering column uses IN (?, ?, ...)
+    val lastCk = ckCols.last
+    val inPlaceholders = Seq.fill(inClauseSize)("?").mkString(", ")
+    val ckInWhere = s"${CqlIdentifier.fromInternal(lastCk.columnName).asCql(true)} IN ($inPlaceholders)"
+
+    val joinWhere = pkWhere ++ ckEqWhere :+ ckInWhere
+    val filter = (queryParts.whereClause.predicates ++ joinWhere).mkString(" AND ")
+    val quotedKeyspaceName = CqlIdentifier.fromInternal(tableDef.keyspaceName).asCql(true)
+    val quotedTableName = CqlIdentifier.fromInternal(tableDef.tableName).asCql(true)
+    val query =
+      s"SELECT $columns " +
+        s"FROM $quotedKeyspaceName.$quotedTableName " +
+        s"WHERE $filter $orderBy $limitClause"
+    logDebug(s"IN-clause batch query: $query")
+    query
+  }
 
   def joinColumnNames(joinColumns: ColumnSelector, tableDef: TableDef): Seq[ColumnRef] = joinColumns match {
     case AllColumns => throw new IllegalArgumentException(
@@ -146,5 +214,91 @@ object JoinHelper extends Logging {
     case None => identity[Row]
   }
 
+  /**
+   * Groups consecutive elements from an iterator by a key function, with a maximum group size.
+   */
+  def groupConsecutive[L](
+    it: Iterator[L],
+    maxGroupSize: Int,
+    keyFn: L => Seq[Any]
+  ): Iterator[Seq[L]] = {
+    val buf: scala.collection.BufferedIterator[L] = it.buffered
+    new Iterator[Seq[L]] {
+      override def hasNext: Boolean = buf.hasNext
+
+      override def next(): Seq[L] = {
+        val first = buf.next()
+        val firstKey = keyFn(first)
+        val group = mutable.ArrayBuffer(first)
+        while (buf.hasNext && group.size < maxGroupSize) {
+          if (keyFn(buf.head) == firstKey) group += buf.next()
+          else return group.toSeq
+        }
+        group.toSeq
+      }
+    }
+  }
+
+  /**
+   * Binds a prepared IN-clause statement with partition key, clustering EQ, and IN values.
+   *
+   * @param group         the left-side elements sharing a partition key
+   * @param preparedStmt  the IN-clause prepared statement
+   * @param rowWriter     writes left-side elements to value buffers
+   * @param codecRegistry codec registry for type conversions
+   * @param prefixVals    where clause prefix values
+   * @param pkIndices     indices of PK columns in the writer buffer
+   * @param ckEqIndices   indices of clustering EQ columns (all but last CK)
+   * @param lastCkIndex   index of the last clustering column in the writer buffer
+   */
+  def bindInClauseStatement[L](
+    group: Seq[L],
+    preparedStmt: PreparedStatement,
+    rowWriter: RowWriter[L],
+    codecRegistry: CodecRegistry,
+    prefixVals: Seq[Any],
+    pkIndices: Seq[Int],
+    ckEqIndices: Seq[Int],
+    lastCkIndex: Int
+  ): BoundStatement = {
+    val writerColCount = rowWriter.columnNames.size
+    val buffer = Array.ofDim[Any](writerColCount)
+    rowWriter.readColumnValues(group.head, buffer)
+
+    var boundStmt = preparedStmt.bind()
+    var paramIdx = 0
+
+    def bindValue(value: Any): Unit = {
+      val paramType = preparedStmt.getVariableDefinitions.get(paramIdx).getType
+      val converter = ColumnType.converterToCassandra(paramType)
+      val converted = converter.convert(value)
+      val codec = CodecRegistryUtil.codecFor(codecRegistry, paramType, converted)
+      boundStmt = boundStmt.set(paramIdx, converted, codec)
+      paramIdx += 1
+    }
+
+    prefixVals.foreach(bindValue)
+    pkIndices.foreach(idx => bindValue(buffer(idx)))
+    ckEqIndices.foreach(idx => bindValue(buffer(idx)))
+    for (elem <- group) {
+      rowWriter.readColumnValues(elem, buffer)
+      bindValue(buffer(lastCkIndex))
+    }
+    boundStmt
+  }
+
+  /** Compare two CK values that might have different runtime types (e.g. Int vs Long). */
+  def ckValuesMatch(leftVal: Any, rightVal: Any): Boolean = {
+    if (leftVal == rightVal) true
+    else (leftVal, rightVal) match {
+      case (l: Number, r: Number) =>
+        l.longValue() == r.longValue() && l.doubleValue() == r.doubleValue()
+      case (l: Comparable[_], r) =>
+        try { l.asInstanceOf[Comparable[Any]].compareTo(r) == 0 }
+        catch { case _: ClassCastException => false }
+      case _ => false
+    }
+  }
 
 }
+

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -19,17 +19,18 @@
 package com.datastax.spark.connector.rdd
 
 import com.datastax.oss.driver.api.core.CqlSession
-import com.datastax.oss.driver.internal.core.cql.ResultSets
+import com.datastax.oss.driver.api.core.cql.PreparedStatement
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.datasource.JoinHelper
+import com.datastax.spark.connector.datasource.ScanHelper.CqlQueryParts
 import com.datastax.spark.connector.rdd.reader._
 import com.datastax.spark.connector.writer._
 import com.google.common.util.concurrent.SettableFuture
 import org.apache.spark.metrics.InputMetricsUpdater
 import org.apache.spark.rdd.RDD
 
-import scala.concurrent.ExecutionContext
+import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success}
 
@@ -135,7 +136,33 @@ class CassandraJoinRDD[L, R] (
     )
   }
 
+  /**
+   * Determines whether IN-clause batching can be applied for the current join configuration.
+   * Batching is only possible when join columns include at least one clustering column
+   * and the configured inClauseSize is greater than 1.
+   */
+  private[rdd] def canBatchJoinQueries: Boolean = {
+    val (_, ckCols) = JoinHelper.splitJoinColumns(tableDef, joinColumnNames)
+    ckCols.nonEmpty && readConf.joinInClauseSize > 1
+  }
+
   private[rdd] def fetchIterator(
+    session: CqlSession,
+    bsb: BoundStatementBuilder[L],
+    rowMetadata: CassandraRowMetadata,
+    leftIterator: Iterator[L],
+    metricsUpdater: InputMetricsUpdater
+  ): Iterator[(L, R)] = {
+
+    if (canBatchJoinQueries) {
+      fetchIteratorWithInClause(session, bsb, rowMetadata, leftIterator, metricsUpdater)
+    } else {
+      fetchIteratorSingle(session, bsb, rowMetadata, leftIterator, metricsUpdater)
+    }
+  }
+
+  /** Original single-row-per-query fetch strategy. */
+  private[rdd] def fetchIteratorSingle(
     session: CqlSession,
     bsb: BoundStatementBuilder[L],
     rowMetadata: CassandraRowMetadata,
@@ -158,8 +185,6 @@ class CassandraJoinRDD[L, R] (
         case Success(rs) =>
           val resultSet = new PrefetchingResultSetIterator(rs)
           val iteratorWithMetrics = resultSet.map(metricsUpdater.updateMetrics)
-          /* This is a much less than ideal place to actually rate limit, we are buffering
-          these futures this means we will most likely exceed our threshold*/
           val throttledIterator = iteratorWithMetrics.map(JoinHelper.maybeRateLimit(readConf))
           val rightSide = throttledIterator.map(rowReader.read(_, rowMetadata))
           resultFuture.set(leftSide.zip(rightSide))
@@ -179,25 +204,122 @@ class CassandraJoinRDD[L, R] (
   }
 
   /**
+   * IN-clause batching fetch strategy. Groups consecutive left-side rows that share
+   * the same partition key and issues a single query with a clustering key IN clause.
+   */
+  private[rdd] def fetchIteratorWithInClause(
+    session: CqlSession,
+    bsb: BoundStatementBuilder[L],
+    rowMetadata: CassandraRowMetadata,
+    leftIterator: Iterator[L],
+    metricsUpdater: InputMetricsUpdater
+  ): Iterator[(L, R)] = {
+
+    import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
+
+    val queryExecutor = QueryExecutor(session, readConf.parallelismLevel, None, None, connector.conf)
+    val codecRegistry = session.getContext.getCodecRegistry
+    val ctx = InClauseContext(session)
+
+    def pairSingleWithRight(left: L): SettableFuture[Iterator[(L, R)]] = {
+      val resultFuture = SettableFuture.create[Iterator[(L, R)]]
+      val stmt = bsb.bind(left).update(_.setPageSize(readConf.fetchSizeInRows)).executeAs(readConf.executeAs)
+      queryExecutor.executeAsync(stmt).onComplete {
+        case Success(rs) =>
+          val it = new PrefetchingResultSetIterator(rs).map(metricsUpdater.updateMetrics)
+          val throttled = it.map(JoinHelper.maybeRateLimit(readConf))
+          resultFuture.set(Iterator.continually(left).zip(throttled.map(rowReader.read(_, rowMetadata))))
+        case Failure(t) => resultFuture.setException(t)
+      }
+      resultFuture
+    }
+
+    def pairGroupWithRight(group: Seq[L]): SettableFuture[Iterator[(L, R)]] = {
+      if (group.size == 1) return pairSingleWithRight(group.head)
+      val resultFuture = SettableFuture.create[Iterator[(L, R)]]
+      val preparedStmt = ctx.getOrPrepare(group.size)
+      val ckValueToLefts = ctx.buildCkValueMap(group)
+      val boundStmt = JoinHelper.bindInClauseStatement(
+        group, preparedStmt, rowWriter, codecRegistry,
+        where.values, ctx.pkIndices, ctx.ckEqIndices, ctx.lastCkIndex
+      ).setPageSize(readConf.fetchSizeInRows)
+      val richStmt = new RichBoundStatementWrapper(boundStmt).executeAs(readConf.executeAs)
+      queryExecutor.executeAsync(richStmt).onComplete {
+        case Success(rs) =>
+          val it = new PrefetchingResultSetIterator(rs).map(metricsUpdater.updateMetrics)
+          val throttled = it.map(JoinHelper.maybeRateLimit(readConf))
+          resultFuture.set(ctx.matchResultsToLefts(throttled, ckValueToLefts, rowMetadata, rowReader))
+        case Failure(t) => resultFuture.setException(t)
+      }
+      resultFuture
+    }
+
+    val groupedIt = JoinHelper.groupConsecutive(leftIterator, readConf.joinInClauseSize, ctx.extractPk)
+    val queryFutures = groupedIt.map { group =>
+      requestsPerSecondRateLimiter.maybeSleep(1)
+      pairGroupWithRight(group)
+    }
+    JoinHelper.slidingPrefetchIterator(queryFutures, readConf.parallelismLevel).flatten
+  }
+
+  /** Encapsulates state needed for IN-clause batching within a partition. */
+  private case class InClauseContext(session: CqlSession) {
+    private val (pkCols, ckCols) = JoinHelper.splitJoinColumns(tableDef, joinColumnNames)
+    private val writerColNames = rowWriter.columnNames
+    private val queryParts = CqlQueryParts(selectedColumnRefs, where, limit, clusteringOrder)
+    private val stmtCache = mutable.Map.empty[Int, PreparedStatement]
+
+    val pkIndices: Seq[Int] = pkCols.map(c => writerColNames.indexOf(c.columnName))
+    val ckEqIndices: Seq[Int] = ckCols.init.map(c => writerColNames.indexOf(c.columnName))
+    val lastCkIndex: Int = writerColNames.indexOf(ckCols.last.columnName)
+    val lastCkColumnName: String = ckCols.last.columnName
+
+    def getOrPrepare(size: Int): PreparedStatement = stmtCache.getOrElseUpdate(size, {
+      val q = JoinHelper.getJoinInQueryString(tableDef, joinColumnNames, queryParts, size)
+      JoinHelper.getJoinPreparedStatement(session, q, consistencyLevel)
+    })
+
+    def extractPk(left: L): Seq[Any] = {
+      val buf = Array.ofDim[Any](writerColNames.size)
+      rowWriter.readColumnValues(left, buf)
+      pkIndices.map(buf(_))
+    }
+
+    def buildCkValueMap(group: Seq[L]): mutable.LinkedHashMap[Any, mutable.ArrayBuffer[L]] = {
+      val map = mutable.LinkedHashMap.empty[Any, mutable.ArrayBuffer[L]]
+      val buf = Array.ofDim[Any](writerColNames.size)
+      for (elem <- group) {
+        rowWriter.readColumnValues(elem, buf)
+        map.getOrElseUpdate(buf(lastCkIndex), mutable.ArrayBuffer.empty) += elem
+      }
+      map
+    }
+
+    def matchResultsToLefts(
+      rows: Iterator[com.datastax.oss.driver.api.core.cql.Row],
+      ckMap: mutable.LinkedHashMap[Any, mutable.ArrayBuffer[L]],
+      rowMetadata: CassandraRowMetadata,
+      rReader: RowReader[R]
+    ): Iterator[(L, R)] = {
+      val ckColIdx = rowMetadata.indexOfCqlColumnOrThrow(lastCkColumnName)
+      rows.flatMap { row =>
+        val right = rReader.read(row, rowMetadata)
+        val ckVal = row.getObject(ckColIdx)
+        val lefts = ckMap.get(ckVal).orElse(
+          ckMap.collectFirst { case (k, v) if JoinHelper.ckValuesMatch(k, ckVal) => v }
+        )
+        lefts.map(_.iterator.map(l => (l, right))).getOrElse(Iterator.empty)
+      }
+    }
+  }
+
+  /**
    * Turns this CassandraJoinRDD into a factory for converting other RDD's after being serialized
-   * This method is for streaming operations as it allows us to Serialize a template JoinRDD
-   * and the use that serializable template in the DStream closure. This gives us a fully serializable
-   * joinWithCassandra operation
    */
   private[connector] def applyToRDD(left: RDD[L]): CassandraJoinRDD[L, R] = {
     new CassandraJoinRDD[L, R](
-      left,
-      keyspaceName,
-      tableName,
-      connector,
-      columnNames,
-      joinColumns,
-      where,
-      limit,
-      clusteringOrder,
-      readConf,
-      Some(rowReader),
-      Some(rowWriter)
+      left, keyspaceName, tableName, connector, columnNames, joinColumns,
+      where, limit, clusteringOrder, readConf, Some(rowReader), Some(rowWriter)
     )
   }
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -19,21 +19,20 @@
 package com.datastax.spark.connector.rdd
 
 import com.datastax.oss.driver.api.core.CqlSession
-import com.datastax.oss.driver.api.core.cql.AsyncResultSet
-import com.datastax.oss.driver.internal.core.cql.ResultSets
+import com.datastax.oss.driver.api.core.cql.PreparedStatement
 import com.datastax.spark.connector._
-import com.datastax.spark.connector.util.maybeExecutingAs
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.datasource.JoinHelper
+import com.datastax.spark.connector.datasource.ScanHelper.CqlQueryParts
 import com.datastax.spark.connector.rdd.reader._
 import com.datastax.spark.connector.writer._
-import com.google.common.util.concurrent.{FutureCallback, Futures, SettableFuture}
+import com.google.common.util.concurrent.SettableFuture
 import org.apache.spark.rdd.RDD
 
+import scala.collection.mutable
 import scala.reflect.ClassTag
 import org.apache.spark.metrics.InputMetricsUpdater
 
-import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
 /**
@@ -140,28 +139,37 @@ class CassandraLeftJoinRDD[L, R] (
 
   /**
    * Turns this CassandraLeftJoinRDD into a factory for converting other RDD's after being serialized
-   * This method is for streaming operations as it allows us to Serialize a template JoinRDD
-   * and the use that serializable template in the DStream closure. This gives us a fully serializable
-   * leftJoinWithCassandra operation
    */
   private[connector] def applyToRDD(left: RDD[L]): CassandraLeftJoinRDD[L, R] = {
     new CassandraLeftJoinRDD[L, R](
-      left,
-      keyspaceName,
-      tableName,
-      connector,
-      columnNames,
-      joinColumns,
-      where,
-      limit,
-      clusteringOrder,
-      readConf,
-      Some(rowReader),
-      Some(rowWriter)
+      left, keyspaceName, tableName, connector, columnNames, joinColumns,
+      where, limit, clusteringOrder, readConf, Some(rowReader), Some(rowWriter)
     )
   }
 
+  /** Whether IN-clause batching can be applied for this join configuration. */
+  private[rdd] def canBatchJoinQueries: Boolean = {
+    val (_, ckCols) = JoinHelper.splitJoinColumns(tableDef, joinColumnNames)
+    ckCols.nonEmpty && readConf.joinInClauseSize > 1
+  }
+
   private[rdd] def fetchIterator(
+    session: CqlSession,
+    bsb: BoundStatementBuilder[L],
+    rowMetadata: CassandraRowMetadata,
+    leftIterator: Iterator[L],
+    metricsUpdater: InputMetricsUpdater
+  ): Iterator[(L, Option[R])] = {
+
+    if (canBatchJoinQueries) {
+      fetchIteratorWithInClause(session, bsb, rowMetadata, leftIterator, metricsUpdater)
+    } else {
+      fetchIteratorSingle(session, bsb, rowMetadata, leftIterator, metricsUpdater)
+    }
+  }
+
+  /** Original single-row-per-query fetch strategy. */
+  private[rdd] def fetchIteratorSingle(
     session: CqlSession,
     bsb: BoundStatementBuilder[L],
     rowMetadata: CassandraRowMetadata,
@@ -183,8 +191,6 @@ class CassandraLeftJoinRDD[L, R] (
         case Success(rs) =>
           val resultSet = new PrefetchingResultSetIterator(rs)
           val iteratorWithMetrics = resultSet.map(metricsUpdater.updateMetrics)
-          /* This is a much less than ideal place to actually rate limit, we are buffering
-          these futures this means we will most likely exceed our threshold*/
           val throttledIterator = iteratorWithMetrics.map(maybeRateLimit)
           val rightSide = resultSet.isEmpty match {
             case true => Iterator.single(None)
@@ -203,5 +209,130 @@ class CassandraLeftJoinRDD[L, R] (
       pairWithRight(left)
     })
     JoinHelper.slidingPrefetchIterator(queryFutures, readConf.parallelismLevel).flatten
+  }
+
+  /**
+   * IN-clause batching fetch strategy for left joins. Groups consecutive left-side rows
+   * sharing the same partition key and issues a single IN-clause query per group.
+   * Left elements with no matching results produce (left, None) pairs.
+   */
+  private[rdd] def fetchIteratorWithInClause(
+    session: CqlSession,
+    bsb: BoundStatementBuilder[L],
+    rowMetadata: CassandraRowMetadata,
+    leftIterator: Iterator[L],
+    metricsUpdater: InputMetricsUpdater
+  ): Iterator[(L, Option[R])] = {
+
+    import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
+
+    val queryExecutor = QueryExecutor(session, readConf.parallelismLevel, None, None, connector.conf)
+    val codecRegistry = session.getContext.getCodecRegistry
+    val ctx = InClauseContext(session)
+
+    def pairSingleWithRight(left: L): SettableFuture[Iterator[(L, Option[R])]] = {
+      val resultFuture = SettableFuture.create[Iterator[(L, Option[R])]]
+      val stmt = bsb.bind(left).update(_.setPageSize(readConf.fetchSizeInRows)).executeAs(readConf.executeAs)
+      queryExecutor.executeAsync(stmt).onComplete {
+        case Success(rs) =>
+          val resultSet = new PrefetchingResultSetIterator(rs)
+          val it = resultSet.map(metricsUpdater.updateMetrics).map(maybeRateLimit)
+          val rightSide = if (resultSet.isEmpty) Iterator.single(None)
+            else it.map(r => Some(rowReader.read(r, rowMetadata)))
+          resultFuture.set(Iterator.continually(left).zip(rightSide))
+        case Failure(t) => resultFuture.setException(t)
+      }
+      resultFuture
+    }
+
+    def pairGroupWithRight(group: Seq[L]): SettableFuture[Iterator[(L, Option[R])]] = {
+      if (group.size == 1) return pairSingleWithRight(group.head)
+      val resultFuture = SettableFuture.create[Iterator[(L, Option[R])]]
+      val preparedStmt = ctx.getOrPrepare(group.size)
+      val ckValueToLefts = ctx.buildCkValueMap(group)
+      val boundStmt = JoinHelper.bindInClauseStatement(
+        group, preparedStmt, rowWriter, codecRegistry,
+        where.values, ctx.pkIndices, ctx.ckEqIndices, ctx.lastCkIndex
+      ).setPageSize(readConf.fetchSizeInRows)
+      val richStmt = new RichBoundStatementWrapper(boundStmt).executeAs(readConf.executeAs)
+      queryExecutor.executeAsync(richStmt).onComplete {
+        case Success(rs) =>
+          val it = new PrefetchingResultSetIterator(rs).map(metricsUpdater.updateMetrics)
+          val throttled = it.map(maybeRateLimit)
+          resultFuture.set(ctx.matchLeftJoinResults(throttled, group, ckValueToLefts, rowMetadata, rowReader))
+        case Failure(t) => resultFuture.setException(t)
+      }
+      resultFuture
+    }
+
+    val groupedIt = JoinHelper.groupConsecutive(leftIterator, readConf.joinInClauseSize, ctx.extractPk)
+    val queryFutures = groupedIt.map { group =>
+      requestsPerSecondRateLimiter.maybeSleep(1)
+      pairGroupWithRight(group)
+    }
+    JoinHelper.slidingPrefetchIterator(queryFutures, readConf.parallelismLevel).flatten
+  }
+
+  /** Encapsulates state needed for IN-clause batching within a partition. */
+  private case class InClauseContext(session: CqlSession) {
+    private val (pkCols, ckCols) = JoinHelper.splitJoinColumns(tableDef, joinColumnNames)
+    private val writerColNames = rowWriter.columnNames
+    private val queryParts = CqlQueryParts(selectedColumnRefs, where, limit, clusteringOrder)
+    private val stmtCache = mutable.Map.empty[Int, PreparedStatement]
+
+    val pkIndices: Seq[Int] = pkCols.map(c => writerColNames.indexOf(c.columnName))
+    val ckEqIndices: Seq[Int] = ckCols.init.map(c => writerColNames.indexOf(c.columnName))
+    val lastCkIndex: Int = writerColNames.indexOf(ckCols.last.columnName)
+    val lastCkColumnName: String = ckCols.last.columnName
+
+    def getOrPrepare(size: Int): PreparedStatement = stmtCache.getOrElseUpdate(size, {
+      val q = JoinHelper.getJoinInQueryString(tableDef, joinColumnNames, queryParts, size)
+      JoinHelper.getJoinPreparedStatement(session, q, consistencyLevel)
+    })
+
+    def extractPk(left: L): Seq[Any] = {
+      val buf = Array.ofDim[Any](writerColNames.size)
+      rowWriter.readColumnValues(left, buf)
+      pkIndices.map(buf(_))
+    }
+
+    def buildCkValueMap(group: Seq[L]): mutable.LinkedHashMap[Any, mutable.ArrayBuffer[L]] = {
+      val map = mutable.LinkedHashMap.empty[Any, mutable.ArrayBuffer[L]]
+      val buf = Array.ofDim[Any](writerColNames.size)
+      for (elem <- group) {
+        rowWriter.readColumnValues(elem, buf)
+        map.getOrElseUpdate(buf(lastCkIndex), mutable.ArrayBuffer.empty) += elem
+      }
+      map
+    }
+
+    /** For left joins: collect results, then emit (left, Some(right)) or (left, None). */
+    def matchLeftJoinResults(
+      rows: Iterator[com.datastax.oss.driver.api.core.cql.Row],
+      group: Seq[L],
+      ckMap: mutable.LinkedHashMap[Any, mutable.ArrayBuffer[L]],
+      rowMeta: CassandraRowMetadata,
+      rReader: reader.RowReader[R]
+    ): Iterator[(L, Option[R])] = {
+      val ckColIdx = rowMeta.indexOfCqlColumnOrThrow(lastCkColumnName)
+      val resultsByCk = mutable.LinkedHashMap.empty[Any, mutable.ArrayBuffer[R]]
+      rows.foreach { row =>
+        val right = rReader.read(row, rowMeta)
+        val ckVal = row.getObject(ckColIdx)
+        resultsByCk.getOrElseUpdate(ckVal, mutable.ArrayBuffer.empty) += right
+      }
+      val buf = Array.ofDim[Any](writerColNames.size)
+      group.iterator.flatMap { left =>
+        rowWriter.readColumnValues(left, buf)
+        val leftCkVal = buf(lastCkIndex)
+        val rights = resultsByCk.get(leftCkVal).orElse(
+          resultsByCk.collectFirst { case (k, v) if JoinHelper.ckValuesMatch(leftCkVal, k) => v }
+        )
+        rights match {
+          case Some(rs) => rs.iterator.map(r => (left, Some(r)))
+          case None => Iterator.single((left, None))
+        }
+      }
+    }
   }
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
@@ -44,7 +44,8 @@ case class ReadConf(
   throughputMiBPS: Option[Double] = None,
   readsPerSec: Option[Int] = ReadConf.ReadsPerSecParam.default,
   parallelismLevel: Int = ReadConf.ParallelismLevelParam.default,
-  executeAs: Option[String] = None)
+  executeAs: Option[String] = None,
+  joinInClauseSize: Int = ReadConf.JoinInClauseSizeParam.default)
 
 
 object ReadConf extends Logging {
@@ -126,6 +127,19 @@ object ReadConf extends Logging {
       """Sets read parallelism for joinWithCassandra tables"""
   )
 
+  val JoinInClauseSizeParam = ConfigParameter[Int] (
+    name = "spark.cassandra.input.join.inClauseSize",
+    section = ReferenceSection,
+    default = 1,
+    description =
+      """Maximum number of clustering key values to batch into a single CQL IN clause
+        | during joinWithCassandraTable operations. When greater than 1, consecutive
+        | left-side rows that share the same partition key are grouped together and
+        | queried with a single SELECT ... WHERE pk = ? AND ck IN (?, ?, ...) statement,
+        | reducing the number of round-trips to the database. Set to 1 to disable
+        | batching (default behavior).""".stripMargin.filter(_ >= ' ')
+  )
+
   def fromSparkConf(conf: SparkConf): ReadConf = {
 
     ConfigCheck.checkConfig(conf)
@@ -138,7 +152,8 @@ object ReadConf extends Logging {
       taskMetricsEnabled = conf.getBoolean(TaskMetricParam.name, TaskMetricParam.default),
       throughputMiBPS = conf.getOption(ThroughputMiBPSParam.name).map(_.toDouble),
       readsPerSec = conf.getOption(ReadsPerSecParam.name).map(_.toInt),
-      parallelismLevel = conf.getInt(ParallelismLevelParam.name, ParallelismLevelParam.default)
+      parallelismLevel = conf.getInt(ParallelismLevelParam.name, ParallelismLevelParam.default),
+      joinInClauseSize = conf.getInt(JoinInClauseSizeParam.name, JoinInClauseSizeParam.default)
     )
   }
 

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
@@ -130,14 +130,15 @@ object ReadConf extends Logging {
   val JoinInClauseSizeParam = ConfigParameter[Int] (
     name = "spark.cassandra.input.join.inClauseSize",
     section = ReferenceSection,
-    default = 1,
+    default = 0,
     description =
-      """Maximum number of clustering key values to batch into a single CQL IN clause
-        | during joinWithCassandraTable operations. When greater than 1, consecutive
-        | left-side rows that share the same partition key are grouped together and
+      """Controls IN-clause batching for joinWithCassandraTable operations.
+        | Set to 0 to disable batching (default). When set to a value greater than 1,
+        | consecutive left-side rows sharing the same partition key are grouped and
         | queried with a single SELECT ... WHERE pk = ? AND ck IN (?, ?, ...) statement,
-        | reducing the number of round-trips to the database. Set to 1 to disable
-        | batching (default behavior).""".stripMargin.filter(_ >= ' ')
+        | reducing round-trips to the database. The value determines the maximum number
+        | of clustering key values per IN clause. Only applies when the join includes
+        | at least one clustering column.""".stripMargin.filter(_ >= ' ')
   )
 
   def fromSparkConf(conf: SparkConf): ReadConf = {

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -348,8 +348,8 @@ columname will be used to set the writetime for that row.</td>
 </tr>
 <tr>
   <td><code>spark.cassandra.input.join.inClauseSize</code></td>
-  <td>1</td>
-  <td>Maximum number of clustering key values to batch into a single CQL IN clause during joinWithCassandraTable operations. When greater than 1, consecutive left-side rows that share the same partition key are grouped together and queried with a single SELECT ... WHERE pk = ? AND ck IN (?, ?, ...) statement, reducing the number of round-trips to the database. Set to 1 to disable batching (default behavior).</td>
+  <td>0</td>
+  <td>Controls IN-clause batching for joinWithCassandraTable operations. Set to 0 to disable batching (default). When set to a value greater than 1, consecutive left-side rows sharing the same partition key are grouped and queried with a single SELECT ... WHERE pk = ? AND ck IN (?, ?, ...) statement, reducing round-trips to the database. The value determines the maximum number of clustering key values per IN clause. Only applies when the join includes at least one clustering column.</td>
 </tr>
 <tr>
   <td><code>spark.cassandra.input.metrics</code></td>

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -347,6 +347,11 @@ columname will be used to set the writetime for that row.</td>
   <td>Number of CQL rows fetched per driver request</td>
 </tr>
 <tr>
+  <td><code>spark.cassandra.input.join.inClauseSize</code></td>
+  <td>1</td>
+  <td>Maximum number of clustering key values to batch into a single CQL IN clause during joinWithCassandraTable operations. When greater than 1, consecutive left-side rows that share the same partition key are grouped together and queried with a single SELECT ... WHERE pk = ? AND ck IN (?, ?, ...) statement, reducing the number of round-trips to the database. Set to 1 to disable batching (default behavior).</td>
+</tr>
+<tr>
   <td><code>spark.cassandra.input.metrics</code></td>
   <td>true</td>
   <td>Sets whether to record connector specific metrics on write</td>


### PR DESCRIPTION
## Summary

- When multiple consecutive left-side rows in a `joinWithCassandraTable` operation share the same partition key, group them and issue a single `SELECT ... WHERE pk = ? AND ck IN (?, ?, ...)` query instead of one query per row, reducing CQL round-trips to the database
- Adds a new configuration parameter `spark.cassandra.input.join.inClauseSize` (default: 1) to control the maximum batch size; set to 1 to preserve current behavior
- Applies to both `CassandraJoinRDD` (inner join) and `CassandraLeftJoinRDD` (left join), with shared binding and grouping utilities extracted into `JoinHelper`

Closes: https://github.com/scylladb/spark-scylladb-connector/issues/73
## Details

The optimization only activates when:
1. The join columns include at least one clustering column (partition-key-only joins already produce one query per partition key)
2. `spark.cassandra.input.join.inClauseSize` is set to a value greater than 1

Grouping is done over consecutive elements only (no global sort or buffering), keeping the implementation streaming-friendly. Prepared statements are cached by IN-clause size to avoid re-preparing. Result rows are matched back to correct left-side elements using the clustering column value from the result set.

### Changed files

| File | Change |
|------|--------|
| `ReadConf.scala` | New `joinInClauseSize` parameter |
| `JoinHelper.scala` | IN-clause query generation, statement binding, grouping, and value matching utilities |
| `CassandraJoinRDD.scala` | `fetchIterator` dispatches to batched or single-row strategy |
| `CassandraLeftJoinRDD.scala` | Same batching support for left joins (unmatched rows emit `None`) |
| `doc/reference.md` | Document the new parameter |

## Test plan

- [x] All 320 existing unit tests pass
- [x] Lint (scalastyle) passes with no errors
- [x] Integration tests with Cassandra (`make test-integration-cassandra`)
- [x] Integration tests with ScyllaDB (`make test-integration-scylla`)
- [x] Manual verification: run a join with `spark.cassandra.input.join.inClauseSize=10` on a table with composite primary key and confirm reduced query count in driver logs
