### PR TITLE
fix: cache token map in batchRoutingKey to avoid per-row lookup

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -180,19 +180,19 @@ class TableWriter[T] private (
     }
   }
 
-  def batchRoutingKey(session: CqlSession)(bs: RichBoundStatementWrapper): Any = {
-    def missingMetadataException = new Supplier[IllegalArgumentException] {
-      override def get(): IllegalArgumentException = new IllegalArgumentException("TokenMap Metadata Missing")
-    }
-
+  def batchRoutingKey(session: CqlSession): RichBoundStatementWrapper => Any = {
     writeConf.batchGroupingKey match {
-      case BatchGroupingKey.None =>  0
+      case BatchGroupingKey.None => (_: RichBoundStatementWrapper) => 0
 
       case BatchGroupingKey.ReplicaSet =>
-        session.getMetadata.getTokenMap.orElseThrow(missingMetadataException)
-          .getReplicas(keyspaceName, QueryUtils.getRoutingKeyOrError(bs.stmt))
+        val tokenMap = session.getMetadata.getTokenMap.orElseThrow(
+          new Supplier[IllegalArgumentException] {
+            override def get(): IllegalArgumentException = new IllegalArgumentException("TokenMap Metadata Missing")
+          })
+        (bs: RichBoundStatementWrapper) => tokenMap.getReplicas(keyspaceName, QueryUtils.getRoutingKeyOrError(bs.stmt))
 
-      case BatchGroupingKey.Partition => QueryUtils.getRoutingKeyOrError(bs.stmt)
+      case BatchGroupingKey.Partition =>
+        (bs: RichBoundStatementWrapper) => QueryUtils.getRoutingKeyOrError(bs.stmt)
     }
   }
 
@@ -243,7 +243,7 @@ class TableWriter[T] private (
         ignoreNulls = writeConf.ignoreNulls)
 
       val batchStmtBuilder = new BatchStatementBuilder(batchType, writeConf.consistencyLevel)
-      val batchKeyGenerator = batchRoutingKey(session) _
+      val batchKeyGenerator = batchRoutingKey(session)
       val batchBuilder = new GroupingBatchBuilderBase(boundStmtBuilder, batchStmtBuilder, batchKeyGenerator,
         writeConf.batchSize, writeConf.batchGroupingBufferSize)
 


### PR DESCRIPTION
## Summary
- Refactored `batchRoutingKey` to return a `RichBoundStatementWrapper => Any` function, capturing the token map once in the closure scope rather than calling `session.getMetadata.getTokenMap` on every row
- The token map is now looked up once when the batch key generator is created, eliminating redundant per-row metadata lookups during `ReplicaSet` batch grouping
- No behavioral change -- the same routing logic applies, just without repeated metadata access

Fixes #74

## Test plan
- [x] Verified compilation succeeds with `./sbt/sbt compile`
- [x] Run unit tests with `make test-unit`
- [x] Run integration tests to verify batch grouping still works correctly with all `BatchGroupingKey` variants (`None`, `ReplicaSet`, `Partition`)