### PR TITLE
fix: apply rate limiter before async submit in TableWriter

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -311,15 +311,15 @@ case class AsyncStatementWriter[T](
 
   def write(record: T): Unit= {
     groupingBatchBuilderBase.batchRecord(record).foreach{ stmt =>
-      queryExecutor.executeAsync(stmt.executeAs(writeConf.executeAs))
       maybeRateLimit(stmt)
+      queryExecutor.executeAsync(stmt.executeAs(writeConf.executeAs))
     }
   }
 
   override def close(): Unit = {
     for (statement <- groupingBatchBuilderBase.finish()) {
-      queryExecutor.executeAsync(statement.executeAs(writeConf.executeAs))
       maybeRateLimit(statement)
+      queryExecutor.executeAsync(statement.executeAs(writeConf.executeAs))
     }
 
     queryExecutor.waitForCurrentlyExecutingTasks()


### PR DESCRIPTION
## Summary
- Moves `maybeRateLimit(stmt)` before `queryExecutor.executeAsync(...)` in both `write()` and `close()` methods of `AsyncStatementWriter`
- Previously, the rate limiter was called after the async statement was already submitted, so throttling had no effect on submission rate
- With this fix, rate limiting properly gates statement submission

Fixes #79

## Test plan
- [x] Verify compilation succeeds
- [x] Confirm rate-limited writes are actually throttled by testing with a low `throughputMiBPS` value