### PR TITLE
Increase default parallelism level from 5 to 10

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -141,7 +141,7 @@ object WriteConf {
   val ParallelismLevelParam = ConfigParameter[Int] (
     name = "spark.cassandra.output.concurrent.writes",
     section = ReferenceSection,
-    default = 5,
+    default = 10,
     description = """Maximum number of batches executed in parallel by a
       | single Spark task""".stripMargin)
 


### PR DESCRIPTION
## Summary
- Increases the default value of `spark.cassandra.output.concurrent.writes` from 5 to 10
- ScyllaDB can handle significantly more concurrent writes than the previous conservative default
- Provides better out-of-the-box write throughput without requiring manual tuning

Fixes #81

## Test plan
- [x] Verified existing tests reference `WriteConf.ParallelismLevelParam.default` (not hardcoded), so no test changes needed
- [x] Run unit tests to confirm no regressions
- [x] Run integration tests with ScyllaDB to validate improved throughput