### PR TITLE
fix: concurrent await in waitForCurrentlyExecutingTasks

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala
@@ -25,7 +25,7 @@ import com.datastax.spark.connector.util.Logging
 
 import scala.jdk.CollectionConverters._
 import scala.collection.concurrent.TrieMap
-import scala.util.Try
+import scala.util.{Success, Try}
 import AsyncExecutor._
 import com.datastax.oss.driver.api.core.{AllNodesFailedException, NodeUnavailableException, NoNodeAvailableException}
 import com.datastax.oss.driver.api.core.connection.BusyConnectionException
@@ -133,8 +133,12 @@ class AsyncExecutor[T, R](asyncAction: T => CompletionStage[R], maxConcurrentTas
     * It will not wait for tasks scheduled for execution during this method call,
     * nor tasks for which the [[executeAsync]] method did not complete. */
   def waitForCurrentlyExecutingTasks(): Unit = {
-    for ((future, _) <- pendingFutures.snapshot())
-      Try(Await.result(future, Duration.Inf))
+    val snapshot = pendingFutures.snapshot().keys.toSeq
+    if (snapshot.nonEmpty) {
+      import scala.concurrent.ExecutionContext.Implicits.global
+      val allSettled = Future.traverse(snapshot)(_.transform(Success(_)))
+      Await.ready(allSettled, Duration.Inf)
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace sequential `Await.result` loop in `waitForCurrentlyExecutingTasks()` with `Future.traverse` that waits for all pending futures concurrently
- Each future is transformed via `Success(_)` to ensure all futures are awaited even if some fail
- Uses `Await.ready` on the combined future instead of individually blocking on each one

Closes #80

## Test plan
- [x] Verify `./sbt/sbt compile` passes
- [x] Run `make test-unit` to confirm no regressions in AsyncExecutor tests
- [x] Review that the behavior is unchanged: all futures are awaited, failures are tolerated
