### PR TITLE
Increase default batch size from 1 KiB to 16 KiB

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -96,7 +96,7 @@ object WriteConf {
   val BatchSizeBytesParam = ConfigParameter[Int](
     name = "spark.cassandra.output.batch.size.bytes",
     section = ReferenceSection,
-    default = 1024,
+    default = 16384,
     description = s"""Maximum total size of the batch in bytes. Overridden by
       |${BatchSizeRowsParam.name}
     """.stripMargin)

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -398,7 +398,7 @@ memory before sending to Cassandra</td>
 </tr>
 <tr>
   <td><code>spark.cassandra.output.batch.size.bytes</code></td>
-  <td>1024</td>
+  <td>16384</td>
   <td>Maximum total size of the batch in bytes. Overridden by
 spark.cassandra.output.batch.size.rows
     </td>


### PR DESCRIPTION
## Summary
- Increases `spark.cassandra.output.batch.size.bytes` default from 1024 (1 KiB) to 16384 (16 KiB)
- The previous default was too small for modern workloads, resulting in batches of only 1-3 rows and excessive round-trips
- The new 16 KiB default provides better throughput while remaining conservative

Fixes #82

## Test plan
- [x] Verified existing test in `WriteConfTest` uses `WriteConf.BatchSizeBytesParam.default` (not a hardcoded value), so it automatically picks up the new default
- [x] No other tests reference the old 1024 value for batch size
- [x] Compilation verified
