### PR TITLE
perf: eliminate lambda allocation per column per row in BoundStatementBuilder

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
@@ -85,11 +85,11 @@ private[connector] class BoundStatementBuilder[T](
     columnValue: AnyRef): Unit = {
 
     if (columnValue == Unset || (ignoreNulls && columnValue == null)) {
-      boundStatement.update(s => s.setToNull(columnName))
+      boundStatement.setToNull(columnName)
       logUnsetToNullWarning = true
     } else {
       val codec = CodecRegistryUtil.codecFor(boundStatement.stmt.codecRegistry(),columnType, columnValue)
-      boundStatement.update(s => s.set(columnName, columnValue, codec))
+      boundStatement.set(columnName, columnValue, codec)
     }
   }
 
@@ -103,7 +103,7 @@ private[connector] class BoundStatementBuilder[T](
       //Do not bind
     } else {
       val codec = CodecRegistryUtil.codecFor(boundStatement.stmt.codecRegistry(),columnType, columnValue)
-      boundStatement.update(s => s.set(columnName, columnValue, codec))
+      boundStatement.set(columnName, columnValue, codec)
     }
   }
 
@@ -142,7 +142,7 @@ private[connector] class BoundStatementBuilder[T](
     }
 
     if (hasAutoTimestamp) {
-      boundStatement.update(_.setLong(TableWriter.AutoTimestampParam, autoTsCounter.getAndIncrement()))
+      boundStatement.setLong(TableWriter.AutoTimestampParam, autoTsCounter.getAndIncrement())
     }
 
     boundStatement.bytesCount = bytesCount

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/RichStatement.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/RichStatement.scala
@@ -21,6 +21,7 @@ package com.datastax.spark.connector.writer
 import java.nio.ByteBuffer
 
 import com.datastax.oss.driver.api.core.ConsistencyLevel
+import com.datastax.oss.driver.api.core.`type`.codec.TypeCodec
 import com.datastax.oss.driver.api.core.cql._
 import com.datastax.spark.connector.util.maybeExecutingAs
 import com.datastax.spark.connector.writer.RichStatement.DriverStatement
@@ -47,6 +48,18 @@ private[connector] class RichBoundStatementWrapper(initStatement: BoundStatement
   private var _stmt = initStatement
   var bytesCount = 0
   val rowsCount = 1
+
+  def setToNull(columnName: String): Unit = {
+    _stmt = _stmt.setToNull(columnName)
+  }
+
+  def set[ValueT](columnName: String, value: ValueT, codec: TypeCodec[ValueT]): Unit = {
+    _stmt = _stmt.set(columnName, value, codec)
+  }
+
+  def setLong(name: String, value: Long): Unit = {
+    _stmt = _stmt.setLong(name, value)
+  }
 
   def setConsistencyLevel(consistencyLevel: ConsistencyLevel): RichBoundStatementWrapper = {
     _stmt = _stmt.setConsistencyLevel(consistencyLevel)


### PR DESCRIPTION
## Summary
- Adds direct mutation methods (`setToNull`, `set`, `setLong`) to `RichBoundStatementWrapper` to avoid allocating a `Function1` lambda object for every column of every row when binding values
- Updates `BoundStatementBuilder.bindColumnNull`, `bindColumnUnset`, and auto-timestamp binding in `bind()` to use the new direct methods instead of `update(s => ...)`
- Reduces GC pressure on the write path where millions of rows with many columns each would previously allocate a short-lived lambda per column

## Test plan
- [x] Verify unit tests pass (`make test-unit`)
- [x] Verify integration tests pass (`make test-integration-cassandra` / `make test-integration-scylla`)
- [x] The changes are semantically equivalent: each new direct method performs the same `_stmt = _stmt.methodCall(...)` that was previously done inside the lambda

Closes #76