### PR TITLE
fix: remove redundant waitForCurrentlyExecutingTasks call in close()

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -333,7 +333,6 @@ case class AsyncStatementWriter[T](
              |Please check the executor logs for more exceptions and information
              """.stripMargin)
     }
-    queryExecutor.waitForCurrentlyExecutingTasks()
     session.close()
   }
 }


### PR DESCRIPTION
## Summary
- Remove the redundant second `waitForCurrentlyExecutingTasks()` call in `AsyncStatementWriter.close()`
- The first call on line 325 already waits for all pending tasks to complete; no new tasks are submitted before the second call on line 336
- If an exception is thrown by `getLatestException()`, the second call is never reached anyway

Closes #77

## Test plan
- [x] Verified the project compiles successfully
- [x] Existing unit and integration tests cover the write path and should pass without changes
