### PR TITLE
fix: avoid unnecessary ArrayBuffer copy in Batch.statements

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/writer/Batch.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/Batch.scala
@@ -32,8 +32,8 @@ private[writer] sealed trait Batch extends Ordered[Batch] {
     * it adds the item regardless of size limitations and always returns `true`. */
   def add(stmt: RichBoundStatementWrapper, force: Boolean = false): Boolean
 
-  /** Collected statements */
-  def statements: Seq[RichBoundStatementWrapper] = buf.toSeq
+  /** Collected statements as a read-only view (avoids copying the underlying buffer). */
+  def statements: scala.collection.Seq[RichBoundStatementWrapper] = buf
 
   /** Only for internal use - batches are compared by this value. */
   protected[Batch] def size: Int

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/BatchStatementBuilder.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/BatchStatementBuilder.scala
@@ -28,7 +28,7 @@ private[connector] class BatchStatementBuilder(
 
   /** Converts a sequence of statements into a batch if its size is greater than 1.
     * Sets the routing key and consistency level. */
-  def maybeCreateBatch(stmts: Seq[RichBoundStatementWrapper]): RichStatement = {
+  def maybeCreateBatch(stmts: scala.collection.Seq[RichBoundStatementWrapper]): RichStatement = {
     require(stmts.nonEmpty, "Statements list cannot be empty")
     val stmt = stmts.head
 

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/RichStatement.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/RichStatement.scala
@@ -64,12 +64,12 @@ private[connector] class RichBoundStatementWrapper(initStatement: BoundStatement
 private[connector] class RichBatchStatementWrapper(
     batchType: BatchType,
     consistencyLevel: ConsistencyLevel,
-    stmts: Seq[RichBoundStatementWrapper])
+    stmts: scala.collection.Seq[RichBoundStatementWrapper])
   extends RichStatement {
 
-  private var _stmt = BatchStatement.newInstance(batchType, stmts.map(_.stmt):_*).setConsistencyLevel(consistencyLevel)
+  private var _stmt = BatchStatement.newInstance(batchType, stmts.view.map(_.stmt).toSeq:_*).setConsistencyLevel(consistencyLevel)
 
-  override val bytesCount: Int = stmts.map(_.bytesCount).sum
+  override val bytesCount: Int = stmts.view.map(_.bytesCount).sum
 
   override val rowsCount = _stmt.size()
 


### PR DESCRIPTION
## Summary

- In Scala 2.13, `ArrayBuffer.toSeq` creates a new `immutable.ArraySeq` by copying all elements. Since `Batch.statements` is always followed by `batch.clear()`, and the returned sequence is only iterated once (to build a `BatchStatement`), this copy is unnecessary.
- Changed `Batch.statements` to return `scala.collection.Seq` (the mutable supertype) and return the buffer directly, avoiding the allocation and copy.
- Updated downstream parameter types in `BatchStatementBuilder.maybeCreateBatch` and `RichBatchStatementWrapper` to accept `scala.collection.Seq`.

Closes #83

## Test plan

- [x] `./sbt/sbt compile` passes
- [x] `./sbt/sbt test` passes (320 tests, 0 failures)
- [x] `make lint` passes (0 errors)
- [x] Integration tests (require CCM setup)