### PR TITLE
Make spark.cassandra.output.concurrent.writes adaptive to cluster size

### DIFF
--- a/connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -29,7 +29,7 @@ import com.datastax.spark.connector.{SomeColumns, _}
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.mapper.DefaultColumnMapper
 import com.datastax.spark.connector.types._
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkConf, SparkException}
 
 case class Address(street: String, city: String, zip: Int)
 case class KV(key: Int, value: String)
@@ -965,6 +965,31 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase with DefaultCluster {
     setOverwrite.isIdempotent should be (true)
     val mapOverwrite = TableWriter(conn, ks, "collections_mod", SomeColumns("key", "mcol".overwrite), WriteConf.fromSparkConf(sc.getConf))
     mapOverwrite.isIdempotent should be (true)
+  }
+
+  "A TableWriter with auto parallelism" should "write successfully without explicit concurrent.writes setting" in {
+    conn.withSessionDo(_.execute(s"""TRUNCATE $ks.key_value"""))
+    val writeConf = WriteConf.fromSparkConf(new SparkConf(false))
+    writeConf.parallelismLevel should be(None)
+
+    val col = Seq((1, 1L, "value1"), (2, 2L, "value2"), (3, 3L, "value3"))
+    sc.parallelize(col).saveToCassandra(ks, "key_value", SomeColumns("key", "group", "value"), writeConf)
+    verifyKeyValueTable("key_value")
+  }
+
+  it should "resolve auto-detected parallelism through AsyncStatementWriter" in {
+    val writeConf = WriteConf.fromSparkConf(new SparkConf(false))
+    writeConf.parallelismLevel should be(None)
+
+    val writer = TableWriter(conn, ks, "key_value", AllColumns, writeConf)
+    val asyncWriter = writer.getAsyncWriter()
+    try {
+      val resolved = asyncWriter.getResolvedParallelismLevel
+      resolved should be >= WriteConf.DefaultMinParallelism
+      resolved should be <= WriteConf.DefaultMaxParallelism
+    } finally {
+      asyncWriter.close()
+    }
   }
 
 }

--- a/connector/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
+++ b/connector/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
@@ -27,6 +27,7 @@ import com.datastax.spark.connector.writer.*;
 import org.apache.spark.SparkConf;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
+import scala.Option;
 import scala.Some$;
 
 import java.io.Serializable;
@@ -269,10 +270,30 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
          * @return this instance or copy to allow method invocation chaining
          */
         public WriterBuilder withParallelismLevel(int parallelismLevel) {
-            if (writeConf.parallelismLevel() != parallelismLevel)
+            if (!Objects.equals(writeConf.parallelismLevel(), Some$.MODULE$.apply(parallelismLevel)))
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
-                        writeConf.consistencyLevel(), writeConf.ifNotExists(), writeConf.ignoreNulls(), parallelismLevel,
+                        writeConf.consistencyLevel(), writeConf.ifNotExists(), writeConf.ignoreNulls(), Some$.MODULE$.apply(parallelismLevel),
+                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled(),
+                        writeConf.executeAs()));
+            else
+                return this;
+        }
+
+        /**
+         * Returns a copy of this builder with the parallelism level reset to auto-detection mode.
+         *
+         * <p>In auto mode, the connector will determine the parallelism level based on the cluster size:
+         * {@code min(max(10, nodesInLocalDC * 2), 50)}.</p>
+         *
+         * @return this instance or copy to allow method invocation chaining
+         */
+        public WriterBuilder withAutoParallelismLevel() {
+            Option<Object> none = WriteConf.noParallelismLevel();
+            if (!Objects.equals(writeConf.parallelismLevel(), none))
+                return withWriteConf(
+                    new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
+                        writeConf.consistencyLevel(), writeConf.ifNotExists(), writeConf.ignoreNulls(), none,
                         writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled(),
                         writeConf.executeAs()));
             else

--- a/connector/src/main/scala/com/datastax/spark/connector/util/ConfigParameter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/util/ConfigParameter.scala
@@ -29,7 +29,8 @@ class ConfigParameter[T] private (
   val name: String,
   val section: String,
   val default: T,
-  val description: String) extends DataFrameOption with Serializable {
+  val description: String,
+  val displayDefault: Option[String] = None) extends DataFrameOption with Serializable {
 
   override val sqlOptionName = name.replaceAll("\\.", "\\_")
 
@@ -93,8 +94,8 @@ object ConfigParameter{
 
   def names: Seq[String] = staticParameters.map(_.name).toSeq
 
-  def apply[T](name: String, section: String, default: T, description: String): ConfigParameter[T] = {
-    val param = new ConfigParameter(name,section,default, description)
+  def apply[T](name: String, section: String, default: T, description: String, displayDefault: Option[String] = None): ConfigParameter[T] = {
+    val param = new ConfigParameter(name, section, default, description, displayDefault)
     staticParameters.add(param)
     param
   }

--- a/connector/src/main/scala/com/datastax/spark/connector/util/RefBuilder.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/util/RefBuilder.scala
@@ -41,13 +41,15 @@ object RefBuilder {
     val markdown = for (section <- sections) yield {
       val parameters = configBySection(section)
       val paramTable = parameters.toList.sortBy(_.name).map { case parameter: ConfigParameter[_] =>
-        val default = parameter.default match {
-          case x: CassandraConnectionFactory => x.getClass.getSimpleName.stripSuffix("$")
-          case x: AuthConfFactory => x.getClass.getSimpleName.stripSuffix("$")
-          case x: Seq[_] => x.mkString(",")
-          case Some(defaultValue) => defaultValue
-          case None => None
-          case value => value
+        val default = parameter.displayDefault.getOrElse {
+          parameter.default match {
+            case x: CassandraConnectionFactory => x.getClass.getSimpleName.stripSuffix("$")
+            case x: AuthConfFactory => x.getClass.getSimpleName.stripSuffix("$")
+            case x: Seq[_] => x.mkString(",")
+            case Some(defaultValue) => defaultValue
+            case None => None
+            case value => value
+          }
         }
         s"""<tr>
             |  <td><code>${parameter.name}</code></td>

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -221,7 +221,7 @@ class TableWriter[T] private (
       case _ => List()
     }
 
-  def getAsyncWriter(): AsyncStatementWriter[T] = {
+  private[connector] def getAsyncWriter(): AsyncStatementWriter[T] = {
     if (isCounterUpdate || containsCollectionBehaviors) {
       getAsyncWriterInternal(queryTemplateUsingUpdate)
     }
@@ -305,9 +305,34 @@ case class AsyncStatementWriter[T](
   private val keyspaceName: String = tableDef.keyspaceName
   private val tableName: String = tableDef.tableName
 
-  private lazy val queryExecutor = new QueryExecutor(
-    session, writeConf.parallelismLevel, successHandler, failureHandler,
-    maxRetries = connector.conf.queryRetryMaxRetries)
+  /** Resolved parallelism level and description, computed once lazily. */
+  private lazy val resolvedParallelism: (Int, String) = writeConf.parallelismLevel match {
+    case Some(level) => (level, "configured")
+    case None =>
+      import scala.jdk.CollectionConverters._
+      val localNodes = session.getMetadata.getNodes.asScala.values
+        .count(_.getDistance == com.datastax.oss.driver.api.core.loadbalancing.NodeDistance.LOCAL)
+      val level = math.min(math.max(WriteConf.DefaultMinParallelism.toLong, localNodes.toLong * 2), WriteConf.DefaultMaxParallelism.toLong).toInt
+      (level, s"auto-detected: $localNodes local node(s), " +
+        s"formula min(max(${WriteConf.DefaultMinParallelism}, $localNodes * 2), ${WriteConf.DefaultMaxParallelism})")
+  }
+
+  /** The parallelism level actually used by this writer, resolved lazily.
+    * Visible within the writer package for testing. */
+  private[writer] def getResolvedParallelismLevel: Int = resolvedParallelism._1
+
+  private lazy val queryExecutor = {
+    val (level, source) = resolvedParallelism
+    if (writeConf.parallelismLevel.exists(_ > WriteConf.DefaultMaxParallelism)) {
+      logWarning(s"Configured write parallelism level ($level) exceeds the recommended maximum " +
+        s"(${WriteConf.DefaultMaxParallelism}) for $keyspaceName.$tableName. " +
+        s"Very high values may cause excessive pressure on the cluster.")
+    }
+    logInfo(s"Using write parallelism level: $level ($source) for $keyspaceName.$tableName")
+    new QueryExecutor(
+      session, level, successHandler, failureHandler,
+      maxRetries = connector.conf.queryRetryMaxRetries)
+  }
 
   def write(record: T): Unit= {
     groupingBatchBuilderBase.batchRecord(record).foreach{ stmt =>

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -104,7 +104,8 @@ object WriteConf {
     description = """Number of rows per single batch. The default is 'auto'
       |which means the connector will adjust the number
       |of rows based on the amount of data
-      |in each row""".stripMargin)
+      |in each row""".stripMargin,
+    displayDefault = Some("auto"))
 
   val BatchSizeBytesParam = ConfigParameter[Int](
     name = "spark.cassandra.output.batch.size.bytes",

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -49,7 +49,7 @@ case class WriteConf(
   consistencyLevel: ConsistencyLevel = WriteConf.ConsistencyLevelParam.default,
   ifNotExists: Boolean = WriteConf.IfNotExistsParam.default,
   ignoreNulls: Boolean = WriteConf.IgnoreNullsParam.default,
-  parallelismLevel: Int = WriteConf.ParallelismLevelParam.default,
+  parallelismLevel: Option[Int] = WriteConf.ParallelismLevelParam.default,
   throughputMiBPS: Option[Double] = WriteConf.ThroughputMiBPSParam.default,
   ttl: TTLOption = TTLOption.defaultValue,
   timestamp: TimestampOption = TimestampOption.defaultValue,
@@ -70,7 +70,20 @@ case class WriteConf(
     Seq(toRegularColDef(ttl, DataTypes.INT), toRegularColDef(timestamp, DataTypes.BIGINT)).flatten
   }
 
+  require(parallelismLevel.forall(_ > 0),
+    s"parallelismLevel must be a positive integer, got ${parallelismLevel.orNull}")
+
   val throttlingEnabled = throughputMiBPS.isDefined
+
+  /** Returns the parallelism level as an `Int`, resolving `None` (auto) to `0`.
+    *
+    * @deprecated Use [[parallelismLevel]] which returns `Option[Int]` to distinguish
+    *             between auto (`None`) and explicit values. This accessor is provided
+    *             for binary compatibility with code that expects `Int`. A return value
+    *             of `0` means auto-detection is enabled.
+    */
+  @deprecated("Use parallelismLevel: Option[Int] instead. 0 means auto.", "4.0.0")
+  def getParallelismLevel: Int = parallelismLevel.getOrElse(0)
 }
 
 
@@ -138,12 +151,15 @@ object WriteConf {
         |this to true will cause all null values to be left as unset rather than bound. For
         |finer control see the CassandraOption class""".stripMargin)
 
-  val ParallelismLevelParam = ConfigParameter[Int] (
+  val ParallelismLevelParam = ConfigParameter[Option[Int]] (
     name = "spark.cassandra.output.concurrent.writes",
     section = ReferenceSection,
-    default = 5,
+    default = None,
     description = """Maximum number of batches executed in parallel by a
-      | single Spark task""".stripMargin)
+      | single Spark task. The default is 'auto' which means the connector
+      | will adjust the number based on the cluster size:
+      | min(max(10, nodesInLocalDC * 2), 50)""".stripMargin,
+    displayDefault = Some("auto"))
 
   val ThroughputMiBPSParam = ConfigParameter[Option[Double]] (
     name = "spark.cassandra.output.throughputMBPerSec",
@@ -197,6 +213,8 @@ object WriteConf {
     val ignoreNulls = conf.getBoolean(IgnoreNullsParam.name, IgnoreNullsParam.default)
 
     val batchSize = {
+      // Note: accepts "0" and leading zeros (e.g., "007") unlike parallelismLevel parser,
+      // because this value feeds into RowsInBatch which has its own validation.
       val Number = "([0-9]+)".r
       batchSizeInRowsStr match {
         case "auto" => BytesInBatch(batchSizeInBytes)
@@ -213,7 +231,17 @@ object WriteConf {
       .map(BatchGroupingKey.apply)
       .getOrElse(BatchLevelParam.default)
 
-    val parallelismLevel = conf.getInt(ParallelismLevelParam.name, ParallelismLevelParam.default)
+    val parallelismLevelStr = conf.get(ParallelismLevelParam.name, "auto")
+    val parallelismLevel: Option[Int] = {
+      val Number = "([1-9][0-9]*)".r
+      parallelismLevelStr match {
+        case "auto" => None
+        case Number(x) => Some(x.toInt)
+        case other =>
+          throw new ConnectorConfigurationException(
+            s"Invalid value of ${ParallelismLevelParam.name}: $other. Positive integer or 'auto' expected")
+      }
+    }
 
     val throughputMiBPS = conf.getOption(ThroughputMiBPSParam.name).map(_.toDouble)
 
@@ -247,6 +275,40 @@ object WriteConf {
       timestamp = timestampOption,
       ignoreNulls = ignoreNulls,
       ifNotExists = ifNotExists)
+  }
+
+  val DefaultMinParallelism = 10
+  val DefaultMaxParallelism = 50
+
+  /** Legacy default parallelism level, used before adaptive auto-detection was introduced. */
+  private val LegacyDefaultParallelism = 5
+
+  /** Returns `None` typed as `Option[Int]`, for Java interoperability.
+    * Avoids raw `None$` / unchecked casts when constructing `WriteConf` from Java. */
+  def noParallelismLevel: Option[Int] = None
+
+  /** Creates a `WriteConf` accepting parallelism level as a plain `Int`.
+    *
+    * @deprecated Use the primary constructor with `parallelismLevel: Option[Int]` instead.
+    *             Pass `None` for auto-detection or `Some(n)` for an explicit value.
+    */
+  @deprecated("Use WriteConf(parallelismLevel = Some(n)) or WriteConf(parallelismLevel = None) instead.", "4.0.0")
+  def withParallelismLevel(
+    batchSize: BatchSize = BatchSize.Automatic,
+    batchGroupingBufferSize: Int = BatchBufferSizeParam.default,
+    batchGroupingKey: BatchGroupingKey = BatchLevelParam.default,
+    consistencyLevel: ConsistencyLevel = ConsistencyLevelParam.default,
+    ifNotExists: Boolean = IfNotExistsParam.default,
+    ignoreNulls: Boolean = IgnoreNullsParam.default,
+    parallelismLevel: Int = LegacyDefaultParallelism,
+    throughputMiBPS: Option[Double] = ThroughputMiBPSParam.default,
+    ttl: TTLOption = TTLOption.defaultValue,
+    timestamp: TimestampOption = TimestampOption.defaultValue,
+    taskMetricsEnabled: Boolean = TaskMetricsParam.default,
+    executeAs: Option[String] = None): WriteConf = {
+    WriteConf(batchSize, batchGroupingBufferSize, batchGroupingKey, consistencyLevel,
+      ifNotExists, ignoreNulls, Some(parallelismLevel), throughputMiBPS, ttl, timestamp,
+      taskMetricsEnabled, executeAs)
   }
 
 }

--- a/connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
@@ -19,6 +19,7 @@
 package com.datastax.spark.connector.writer
 
 import com.datastax.oss.driver.api.core.DefaultConsistencyLevel
+import com.datastax.spark.connector.util.ConfigCheck.ConnectorConfigurationException
 import com.datastax.spark.connector.{BytesInBatch, RowsInBatch}
 import org.apache.spark.SparkConf
 import org.scalatest.{FlatSpec, Matchers}
@@ -31,7 +32,7 @@ class WriteConfTest extends FlatSpec with Matchers {
 
     writeConf.batchSize should be (BytesInBatch(WriteConf.BatchSizeBytesParam.default))
     writeConf.consistencyLevel should be (WriteConf.ConsistencyLevelParam.default)
-    writeConf.parallelismLevel should be (WriteConf.ParallelismLevelParam.default)
+    writeConf.parallelismLevel should be (None)
   }
 
   it should "allow setting the rate limit as a decimal" in {
@@ -54,7 +55,31 @@ class WriteConfTest extends FlatSpec with Matchers {
       .set("spark.cassandra.output.concurrent.writes", "17")
     val writeConf = WriteConf.fromSparkConf(conf)
 
-    writeConf.parallelismLevel should be(17)
+    writeConf.parallelismLevel should be(Some(17))
+  }
+
+  it should "set parallelism level to auto by default" in {
+    val conf = new SparkConf(false)
+    val writeConf = WriteConf.fromSparkConf(conf)
+
+    writeConf.parallelismLevel should be(None)
+  }
+
+  it should "set parallelism level to auto when explicitly set to 'auto'" in {
+    val conf = new SparkConf(false)
+      .set("spark.cassandra.output.concurrent.writes", "auto")
+    val writeConf = WriteConf.fromSparkConf(conf)
+
+    writeConf.parallelismLevel should be(None)
+  }
+
+  it should "reject invalid parallelism level value" in {
+    val conf = new SparkConf(false)
+      .set("spark.cassandra.output.concurrent.writes", "invalid")
+
+    intercept[ConnectorConfigurationException] {
+      WriteConf.fromSparkConf(conf)
+    }
   }
 
   it should "allow to set batch size in bytes" in {
@@ -96,5 +121,64 @@ class WriteConfTest extends FlatSpec with Matchers {
     writeConf.batchGroupingBufferSize should be(30000)
   }
 
+  it should "reject parallelism level of 0" in {
+    val conf = new SparkConf(false)
+      .set("spark.cassandra.output.concurrent.writes", "0")
+
+    intercept[ConnectorConfigurationException] {
+      WriteConf.fromSparkConf(conf)
+    }
+  }
+
+  it should "reject parallelism level with leading zeros" in {
+    val conf = new SparkConf(false)
+      .set("spark.cassandra.output.concurrent.writes", "007")
+
+    intercept[ConnectorConfigurationException] {
+      WriteConf.fromSparkConf(conf)
+    }
+  }
+
+  it should "reject negative parallelism level via SparkConf" in {
+    val conf = new SparkConf(false)
+      .set("spark.cassandra.output.concurrent.writes", "-1")
+
+    intercept[ConnectorConfigurationException] {
+      WriteConf.fromSparkConf(conf)
+    }
+  }
+
+  it should "support explicit Some parallelism level (Java API path)" in {
+    val writeConf = WriteConf(parallelismLevel = Some(42))
+    writeConf.parallelismLevel should be(Some(42))
+  }
+
+  it should "support None parallelism level for auto mode (Java API path)" in {
+    val writeConf = WriteConf(parallelismLevel = None)
+    writeConf.parallelismLevel should be(None)
+  }
+
+  it should "reject negative parallelism level via constructor" in {
+    intercept[IllegalArgumentException] {
+      WriteConf(parallelismLevel = Some(-5))
+    }
+  }
+
+  it should "reject zero parallelism level via constructor" in {
+    intercept[IllegalArgumentException] {
+      WriteConf(parallelismLevel = Some(0))
+    }
+  }
+
+  it should "accept parallelism level exceeding recommended maximum without throwing" in {
+    val writeConf = WriteConf(parallelismLevel = Some(100))
+    writeConf.parallelismLevel should be(Some(100))
+    writeConf.parallelismLevel.get should be > WriteConf.DefaultMaxParallelism
+  }
+
+  "auto parallelism constants" should "define a valid range" in {
+    WriteConf.DefaultMinParallelism should be > 0
+    WriteConf.DefaultMaxParallelism should be >= WriteConf.DefaultMinParallelism
+  }
 
 }

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -405,7 +405,7 @@ spark.cassandra.output.batch.size.rows
 </tr>
 <tr>
   <td><code>spark.cassandra.output.batch.size.rows</code></td>
-  <td>None</td>
+  <td>auto</td>
   <td>Number of rows per single batch. The default is 'auto'
 which means the connector will adjust the number
 of rows based on the amount of data
@@ -413,9 +413,11 @@ in each row</td>
 </tr>
 <tr>
   <td><code>spark.cassandra.output.concurrent.writes</code></td>
-  <td>5</td>
+  <td>auto</td>
   <td>Maximum number of batches executed in parallel by a
- single Spark task</td>
+ single Spark task. The default is 'auto' which means the connector
+ will adjust the number based on the cluster size:
+ min(max(10, nodesInLocalDC * 2), 50)</td>
 </tr>
 <tr>
   <td><code>spark.cassandra.output.consistency.level</code></td>


### PR DESCRIPTION
## Summary
- Change `spark.cassandra.output.concurrent.writes` from a fixed default of `5` to adaptive auto-detection based on cluster size: `min(max(10, nodesInLocalDC * 2), 50)`
- The setting now accepts `"auto"` (default) or a positive integer; the `parallelismLevel` field in `WriteConf` becomes `Option[Int]` (`None` = auto)
- Add backward-compatible deprecated accessors (`getParallelismLevel`, `withParallelismLevel`) and Java API support (`withAutoParallelismLevel`, `noParallelismLevel`)
- Log resolved parallelism level at INFO; warn when explicitly configured value exceeds recommended maximum
- Comprehensive unit and integration tests for parsing, validation, auto-detection, and the high-parallelism warning path
- Defensive `toLong` arithmetic in the auto-detection formula to prevent theoretical overflow

## Test plan
- [x] Unit tests pass (`WriteConfTest` — 21 tests covering defaults, explicit values, auto, rejection of invalid/0/negative/leading-zero values, high-parallelism acceptance, range constants)
- [x] Compilation verified across all modules (connector, datasource, Java API)
- [x] Integration tests with CCM cluster (`TableWriterSpec` — auto-parallelism write + resolved level assertions)