### PR TITLE
SPARKC-505 Add WriteConf to delete and update query templates

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,7 +3,18 @@ Unreleased
    avoiding DefaultBatchStatement warnings (#98)
  * Avoid requiring ignored per-row write option placeholders for counter updates (#102)
  * Avoid auto timestamp bind marker collisions with user columns (#103)
- 
+ * Restore TableWriter.delete(ColumnSelector) source compatibility (SPARKC-505)
+ * Avoid requiring ignored per-row write option placeholders for counter updates (SPARKC-505)
+ * Restore WriteConf.optionsAsColumns compatibility (SPARKC-505)
+ * Bind duplicate per-row write option markers by index (SPARKC-505)
+ * Preserve case-sensitive quoted bind marker lookup (SPARKC-505)
+ * Preserve prefix bind values when duplicate marker names are bound by index (SPARKC-505)
+ * Fail fast when INSERT per-row write option placeholders are not selected (SPARKC-505)
+ * Quote per-row write option bind markers when placeholder names require it (SPARKC-505)
+ * Bind DELETE-only per-row option placeholders with option types when names match real columns (SPARKC-505)
+ * Preserve tuple positions for DELETE with ignored per-row TTL and per-row timestamp (SPARKC-505)
+ * Avoid reading ignored DELETE TTL placeholders from named rows (SPARKC-505)
+
 3.5.1
  * Support for Vector type available in Cassandra 5.0 (SPARKC-706)
  * Upgrade Cassandra Java Driver to 4.18.1, support Cassandra 5.0 in test framework (SPARKC-710)

--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,8 @@ lazy val commonSettings = Seq(
   dependencyUpdatesFailBuild := true,
   dependencyUpdatesFilter -= moduleFilter(organization = "org.scala-lang"),
   fork := true,
+  Test / javaOptions += "-Dnet.bytebuddy.experimental=true",
+  IntegrationTest / javaOptions += "-Dnet.bytebuddy.experimental=true",
   parallelExecution := true,
   testForkedParallel := false,
   testOptions += Tests.Argument(TestFrameworks.JUnit, "-v"),

--- a/connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITFlatSpecBase.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITFlatSpecBase.scala
@@ -19,6 +19,7 @@
 package com.datastax.spark.connector
 
 import java.io.{ByteArrayOutputStream, ObjectOutputStream}
+import java.time.{ZoneId, ZonedDateTime}
 import java.util.concurrent.Executors
 
 import com.datastax.dse.driver.api.core.metadata.DseNodeProperties
@@ -277,6 +278,10 @@ trait SparkCassandraITSpecBase
     }
     throw lastException
   }
+
+  /** Converts a year to a Cassandra-style microsecond timestamp (midnight UTC on Jan 1 of that year). */
+  protected def microsAtYear(year: Int): Long =
+    ZonedDateTime.of(year, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC")).toInstant.toEpochMilli * 1000L
 
   def keyspaceCql(name: String = ks) =
     s"""

--- a/connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -33,6 +33,7 @@ import com.datastax.spark.connector.cql.{CassandraConnector, CassandraConnectorC
 import com.datastax.spark.connector.mapper.{DefaultColumnMapper, JavaBeanColumnMapper, JavaTestBean, JavaTestUDTBean}
 import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory
 import com.datastax.spark.connector.types.{CassandraOption, TypeConverter}
+import com.datastax.spark.connector.writer.{TimestampOption, TTLOption, WriteConf}
 import com.datastax.spark.connector.util.RuntimeUtil
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException
 
@@ -329,7 +330,17 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase with DefaultCluster 
           executor.execute(newInstance(s"INSERT INTO $ks.date_test (key, dd) VALUES (1, '1930-05-31')"))
         }
       }
+
     )
+    awaitAll(Seq(
+      "delete_with_old_timestamp", "delete_with_future_timestamp", "delete_ignore_ttl",
+      "delete_per_row_ts", "delete_col_ts", "delete_col_old_ts", "delete_col_per_row_ts",
+      "delete_per_row_ttl_ts", "delete_per_row_ttl_without_column", "delete_all_columns",
+      "delete_all_cols_per_row_ts"
+    ).map(t => Future {
+      executor.execute(newInstance(s"""CREATE TABLE $ks.$t(key INT, group INT, value VARCHAR, PRIMARY KEY (key, group))"""))
+    }))
+    executor.execute(newInstance(s"""CREATE TABLE $ks.delete_pk_only_all_columns(key INT, group INT, PRIMARY KEY (key, group))"""))
     executor.waitForCurrentlyExecutingTasks()
     }
   }
@@ -1297,6 +1308,200 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase with DefaultCluster 
 
   }
 
+  private val insertTs = microsAtYear(2010)
+
+  private def setupDeleteTestTable(tableName: String): Unit = {
+    conn.withSessionDo { session =>
+      session.execute(s"""TRUNCATE $ks.$tableName""")
+      for ((k, g, v) <- Seq((10,10,"1010"),(10,11,"1011"),(10,12,"1012"),(20,20,"2020"),(20,21,"2021"),(20,22,"2022")))
+        session.execute(s"""INSERT INTO $ks.$tableName(key, group, value) VALUES ($k, $g, '$v') USING TIMESTAMP $insertTs""")
+    }
+  }
+
+  it should "not delete rows when delete timestamp is older than write timestamp" in {
+    setupDeleteTestTable("delete_with_old_timestamp")
+
+    sc.cassandraTable(ks, "delete_with_old_timestamp").where("key = 10")
+      .deleteFromCassandra(ks, "delete_with_old_timestamp",
+        writeConf = WriteConf(timestamp = TimestampOption.constant(microsAtYear(2000))))
+
+    val results1 = sc
+      .cassandraTable[(Int, Int, String)](ks, "delete_with_old_timestamp")
+      .select("key", "group", "value")
+      .collect()
+
+    results1 should have size 6
+
+  }
+
+  it should "delete rows when delete timestamp is newer than write timestamp" in {
+    setupDeleteTestTable("delete_with_future_timestamp")
+
+    sc.cassandraTable(ks, "delete_with_future_timestamp").where("key = 10")
+      .deleteFromCassandra(ks, "delete_with_future_timestamp",
+        writeConf = WriteConf(timestamp = TimestampOption.constant(microsAtYear(2020))))
+
+    val results1 = sc
+      .cassandraTable[(Int, Int, String)](ks, "delete_with_future_timestamp")
+      .select("key", "group", "value")
+      .collect()
+
+    results1 should have size 3
+
+  }
+
+  it should "delete rows and ignore ttl setting" in {
+    setupDeleteTestTable("delete_ignore_ttl")
+
+    sc.cassandraTable(ks, "delete_ignore_ttl").where("key = 10")
+      .deleteFromCassandra(ks, "delete_ignore_ttl",
+        writeConf = WriteConf(ttl = TTLOption.constant(13456)))
+
+    val results1 = sc
+      .cassandraTable[(Int, Int, String)](ks, "delete_ignore_ttl")
+      .select("key", "group", "value")
+      .collect()
+
+    results1 should have size 3
+    results1 should contain theSameElementsAs Seq(
+      (20, 20, "2020"),
+      (20, 21, "2021"),
+      (20, 22, "2022"))
+
+  }
+
+  it should "delete rows with per-row TTL when TTL column is omitted" in {
+    setupDeleteTestTable("delete_per_row_ttl_without_column")
+
+    sc.parallelize(Seq((10, 10), (10, 11)))
+      .deleteFromCassandra(ks, "delete_per_row_ttl_without_column",
+        writeConf = WriteConf(ttl = TTLOption.perRow("ignored_ttl")))
+
+    val results = sc
+      .cassandraTable[(Int, Int, String)](ks, "delete_per_row_ttl_without_column")
+      .select("key", "group", "value")
+      .collect()
+
+    results should have size 4
+    results should contain theSameElementsAs Seq(
+      (10, 12, "1012"),
+      (20, 20, "2020"),
+      (20, 21, "2021"),
+      (20, 22, "2022"))
+  }
+
+  it should "delete rows using per-row timestamp" in {
+    conn.withSessionDo { session =>
+      session.execute(s"""TRUNCATE $ks.delete_per_row_ts""")
+      session.execute(s"""INSERT INTO $ks.delete_per_row_ts(key, group, value) VALUES (10, 10, '1010') USING TIMESTAMP $insertTs""")
+      session.execute(s"""INSERT INTO $ks.delete_per_row_ts(key, group, value) VALUES (10, 11, '1011') USING TIMESTAMP $insertTs""")
+      session.execute(s"""INSERT INTO $ks.delete_per_row_ts(key, group, value) VALUES (20, 20, '2020') USING TIMESTAMP $insertTs""")
+    }
+
+    // Use a newer timestamp so the delete succeeds for key=10, older timestamp for key=20
+    val newerTs = microsAtYear(2020)
+    val olderTs = microsAtYear(2000)
+
+    sc.parallelize(Seq((10, 10, newerTs), (20, 20, olderTs)))
+      .deleteFromCassandra(ks, "delete_per_row_ts",
+        writeConf = WriteConf(timestamp = TimestampOption.perRow("write_ts")))
+
+    val results = sc
+      .cassandraTable[(Int, Int, String)](ks, "delete_per_row_ts")
+      .select("key", "group", "value")
+      .collect()
+
+    // key=10,group=10 should be deleted (newer timestamp), key=20,group=20 should remain (older timestamp)
+    results should have size 2
+    results should contain theSameElementsAs Seq(
+      (10, 11, "1011"),
+      (20, 20, "2020"))
+
+  }
+
+  it should "delete specific columns with timestamp and preserve other columns" in {
+    conn.withSessionDo { session =>
+      session.execute(s"""TRUNCATE $ks.delete_col_ts""")
+      session.execute(s"""INSERT INTO $ks.delete_col_ts(key, group, value) VALUES (10, 10, '1010') USING TIMESTAMP $insertTs""")
+      session.execute(s"""INSERT INTO $ks.delete_col_ts(key, group, value) VALUES (10, 11, '1011') USING TIMESTAMP $insertTs""")
+      session.execute(s"""INSERT INTO $ks.delete_col_ts(key, group, value) VALUES (20, 20, '2020') USING TIMESTAMP $insertTs""")
+    }
+
+    // Delete only the "value" column using a newer timestamp
+    val newerTs = microsAtYear(2020)
+    sc.cassandraTable(ks, "delete_col_ts").where("key = 10")
+      .deleteFromCassandra(ks, "delete_col_ts",
+        deleteColumns = SomeColumns("value"),
+        writeConf = WriteConf(timestamp = TimestampOption.constant(newerTs)))
+
+    val results = sc
+      .cassandraTable[(Int, Int, Option[String])](ks, "delete_col_ts")
+      .select("key", "group", "value")
+      .collect()
+
+    // Rows should still exist but value column should be null for key=10
+    results should have size 3
+    results should contain theSameElementsAs Seq(
+      (10, 10, None),
+      (10, 11, None),
+      (20, 20, Some("2020")))
+  }
+
+  it should "not delete specific columns when delete timestamp is older than write timestamp" in {
+    conn.withSessionDo { session =>
+      session.execute(s"""TRUNCATE $ks.delete_col_old_ts""")
+      session.execute(s"""INSERT INTO $ks.delete_col_old_ts(key, group, value) VALUES (10, 10, '1010') USING TIMESTAMP $insertTs""")
+      session.execute(s"""INSERT INTO $ks.delete_col_old_ts(key, group, value) VALUES (10, 11, '1011') USING TIMESTAMP $insertTs""")
+    }
+
+    // Delete with an older timestamp — should have no effect
+    val olderTs = microsAtYear(2000)
+    sc.cassandraTable(ks, "delete_col_old_ts").where("key = 10")
+      .deleteFromCassandra(ks, "delete_col_old_ts",
+        deleteColumns = SomeColumns("value"),
+        writeConf = WriteConf(timestamp = TimestampOption.constant(olderTs)))
+
+    val results = sc
+      .cassandraTable[(Int, Int, String)](ks, "delete_col_old_ts")
+      .select("key", "group", "value")
+      .collect()
+
+    // Value column should remain because the delete timestamp is older than the write timestamp
+    results should have size 2
+    results should contain theSameElementsAs Seq(
+      (10, 10, "1010"),
+      (10, 11, "1011"))
+  }
+
+  it should "delete specific columns using per-row timestamp" in {
+    conn.withSessionDo { session =>
+      session.execute(s"""TRUNCATE $ks.delete_col_per_row_ts""")
+      session.execute(s"""INSERT INTO $ks.delete_col_per_row_ts(key, group, value) VALUES (10, 10, '1010') USING TIMESTAMP $insertTs""")
+      session.execute(s"""INSERT INTO $ks.delete_col_per_row_ts(key, group, value) VALUES (20, 20, '2020') USING TIMESTAMP $insertTs""")
+    }
+
+    val newerTs = microsAtYear(2020)
+    val olderTs = microsAtYear(2000)
+
+    // Delete only the "value" column with per-row timestamps:
+    // newer timestamp for key=10 (should null out value), older timestamp for key=20 (should leave value intact)
+    sc.parallelize(Seq((10, 10, newerTs), (20, 20, olderTs)))
+      .deleteFromCassandra(ks, "delete_col_per_row_ts",
+        deleteColumns = SomeColumns("value"),
+        keyColumns = SomeColumns("key", "group", "write_ts"),
+        writeConf = WriteConf(timestamp = TimestampOption.perRow("write_ts")))
+
+    val results = sc
+      .cassandraTable[(Int, Int, Option[String])](ks, "delete_col_per_row_ts")
+      .select("key", "group", "value")
+      .collect()
+
+    results should have size 2
+    results should contain theSameElementsAs Seq(
+      (10, 10, None),
+      (20, 20, Some("2020")))
+  }
+
   it should "delete rows with specified mapping" in {
 
     sc.cassandraTable[(Int, Int)](ks, "delete_wide_rows2")
@@ -1383,6 +1588,106 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase with DefaultCluster 
       (10, 11, Some("1011")),
       (10, 12, Some("1012")))
 
+  }
+
+  it should "delete rows with per-row TTL and per-row TIMESTAMP ignoring TTL" in {
+    conn.withSessionDo { session =>
+      session.execute(s"""TRUNCATE $ks.delete_per_row_ttl_ts""")
+      session.execute(s"""INSERT INTO $ks.delete_per_row_ttl_ts(key, group, value) VALUES (10, 10, '1010') USING TIMESTAMP $insertTs""")
+      session.execute(s"""INSERT INTO $ks.delete_per_row_ttl_ts(key, group, value) VALUES (20, 20, '2020') USING TIMESTAMP $insertTs""")
+    }
+
+    val newerTs = microsAtYear(2020)
+    val olderTs = microsAtYear(2000)
+
+    // TTL should be stripped for DELETE; only TIMESTAMP should take effect
+    sc.parallelize(Seq((10, 10, 99999, newerTs), (20, 20, 99999, olderTs)))
+      .deleteFromCassandra(ks, "delete_per_row_ttl_ts",
+        writeConf = WriteConf(
+          ttl = TTLOption.perRow("ttl"),
+          timestamp = TimestampOption.perRow("ts")))
+
+    val results = sc
+      .cassandraTable[(Int, Int, String)](ks, "delete_per_row_ttl_ts")
+      .select("key", "group", "value")
+      .collect()
+
+    // key=10 deleted (future timestamp), key=20 retained (past timestamp)
+    results should have size 1
+    results should contain theSameElementsAs Seq((20, 20, "2020"))
+  }
+
+  it should "delete non-PK columns when deleteColumns is AllColumns" in {
+    conn.withSessionDo { session =>
+      session.execute(s"""TRUNCATE $ks.delete_all_columns""")
+      session.execute(s"""INSERT INTO $ks.delete_all_columns(key, group, value) VALUES (10, 10, '1010')""")
+      session.execute(s"""INSERT INTO $ks.delete_all_columns(key, group, value) VALUES (20, 20, '2020')""")
+    }
+
+    sc.parallelize(Seq((10, 10), (20, 20)))
+      .deleteFromCassandra(ks, "delete_all_columns", deleteColumns = AllColumns)
+
+    val results = sc
+      .cassandraTable[(Int, Int, Option[String])](ks, "delete_all_columns")
+      .select("key", "group", "value")
+      .collect()
+
+    // Rows still exist (primary keys remain) but value column is nulled out
+    results should have size 2
+    results should contain theSameElementsAs Seq(
+      (10, 10, None),
+      (20, 20, None))
+  }
+
+  it should "delete non-PK columns when deleteColumns is AllColumns with per-row timestamp" in {
+    conn.withSessionDo { session =>
+      session.execute(s"""TRUNCATE $ks.delete_all_cols_per_row_ts""")
+      session.execute(s"""INSERT INTO $ks.delete_all_cols_per_row_ts(key, group, value) VALUES (10, 10, '1010') USING TIMESTAMP $insertTs""")
+      session.execute(s"""INSERT INTO $ks.delete_all_cols_per_row_ts(key, group, value) VALUES (20, 20, '2020') USING TIMESTAMP $insertTs""")
+    }
+
+    val newerTs = microsAtYear(2020)
+    val olderTs = microsAtYear(2000)
+
+    // Delete all non-PK columns with per-row timestamps:
+    // newer timestamp for key=10 (should null out value), older timestamp for key=20 (should leave value intact)
+    sc.parallelize(Seq((10, 10, newerTs), (20, 20, olderTs)))
+      .deleteFromCassandra(ks, "delete_all_cols_per_row_ts",
+        deleteColumns = AllColumns,
+        keyColumns = SomeColumns("key", "group", "write_ts"),
+        writeConf = WriteConf(timestamp = TimestampOption.perRow("write_ts")))
+
+    val results = sc
+      .cassandraTable[(Int, Int, Option[String])](ks, "delete_all_cols_per_row_ts")
+      .select("key", "group", "value")
+      .collect()
+
+    // key=10 value should be nulled out (future timestamp), key=20 value should remain (past timestamp)
+    results should have size 2
+    results should contain theSameElementsAs Seq(
+      (10, 10, None),
+      (20, 20, Some("2020")))
+  }
+
+  it should "delete a partition on a PK-only table when deleteColumns is AllColumns" in {
+    conn.withSessionDo { session =>
+      session.execute(s"""TRUNCATE $ks.delete_pk_only_all_columns""")
+      session.execute(s"""INSERT INTO $ks.delete_pk_only_all_columns(key, group) VALUES (10, 10)""")
+      session.execute(s"""INSERT INTO $ks.delete_pk_only_all_columns(key, group) VALUES (10, 11)""")
+      session.execute(s"""INSERT INTO $ks.delete_pk_only_all_columns(key, group) VALUES (20, 20)""")
+    }
+
+    sc.parallelize(Seq(Key(10)))
+      .deleteFromCassandra(ks, "delete_pk_only_all_columns",
+        deleteColumns = AllColumns,
+        keyColumns = SomeColumns("key"))
+
+    val results = sc
+      .cassandraTable[(Int, Int)](ks, "delete_pk_only_all_columns")
+      .select("key", "group")
+      .collect()
+
+    results should contain theSameElementsAs Seq((20, 20))
   }
 
   "DataSize Estimates" should "handle overflows in the size estimates for a table" in {

--- a/connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/DataSizeEstimatesSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/DataSizeEstimatesSpec.scala
@@ -29,6 +29,7 @@ class DataSizeEstimatesSpec extends SparkCassandraITFlatSpecBase with DefaultClu
   override lazy val conn = CassandraConnector(defaultConf)
 
   val tableName = "table1"
+  val rowCount = 1000
 
   override def beforeClass: Unit = {
     conn.withSessionDo { session => createKeyspace(session) }
@@ -39,7 +40,7 @@ class DataSizeEstimatesSpec extends SparkCassandraITFlatSpecBase with DefaultClu
       session.execute(s"CREATE TABLE $ks.$tableName(key int PRIMARY KEY, value VARCHAR)")
       val ps = session.prepare(s"INSERT INTO $ks.$tableName(key, value) VALUES (?, ?)")
       awaitAll(
-        for (i <- 1 to 1000) yield
+        for (i <- 1 to rowCount) yield
           executor.executeAsync(ps.bind(i.asInstanceOf[AnyRef], "value" + i))
       )
       executor.waitForCurrentlyExecutingTasks()
@@ -50,8 +51,8 @@ class DataSizeEstimatesSpec extends SparkCassandraITFlatSpecBase with DefaultClu
 
   "DataSizeEstimates" should "fetch data size estimates for a known table" in {
     val estimates = new DataSizeEstimates[Long, LongToken](conn, ks, tableName)
-    estimates.partitionCount should be > 500L
-    estimates.partitionCount should be < 2000L
+    estimates.partitionCount should be > (rowCount / 2L)
+    estimates.partitionCount should be <= (rowCount * 2L)
     estimates.dataSizeInBytes should be > 0L
   }
 

--- a/connector/src/it/scala/com/datastax/spark/connector/streaming/RDDStreamingSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/streaming/RDDStreamingSpec.scala
@@ -25,6 +25,7 @@ import com.datastax.spark.connector._
 import com.datastax.spark.connector.cluster.DefaultCluster
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.testkit._
+import com.datastax.spark.connector.writer.{TimestampOption, WriteConf}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.{Milliseconds, StreamingContext}
 import org.scalatest.concurrent.Eventually
@@ -75,6 +76,15 @@ class RDDStreamingSpec extends SparkCassandraITFlatSpecBase with DefaultCluster
           session.execute(s"INSERT INTO $ks.streaming_deletes (word, count) VALUES ('1words', 1)")
           session.execute(s"INSERT INTO $ks.streaming_deletes (word, count) VALUES ('1round', 2)")
           session.execute(s"INSERT INTO $ks.streaming_deletes (word, count) VALUES ('survival', 3)")
+        },
+        Future {
+          session.execute(s"CREATE TABLE $ks.streaming_deletes_with_ts (word TEXT PRIMARY KEY, count INT)")
+          // Insert rows with a known old timestamp (year 2000)
+          val oldTs = microsAtYear(2000)
+          session.execute(s"INSERT INTO $ks.streaming_deletes_with_ts (word, count) VALUES ('old_row', 1) USING TIMESTAMP $oldTs")
+          // Insert a row with a newer timestamp (year 2020)
+          val newerTs = microsAtYear(2020)
+          session.execute(s"INSERT INTO $ks.streaming_deletes_with_ts (word, count) VALUES ('future_row', 2) USING TIMESTAMP $newerTs")
         }
       )
       executor.waitForCurrentlyExecutingTasks()
@@ -216,6 +226,30 @@ class RDDStreamingSpec extends SparkCassandraITFlatSpecBase with DefaultCluster
       val result = rdd.collect
       result.length should be(1)
       result(0) should be(WordCount("survival", 3))
+    }
+  }
+
+  it should "delete rows from cassandra table using WriteConf timestamp via DStream" in withStreamingContext { ssc =>
+    // Delete with a timestamp between old (2000) and newer (2020) rows.
+    // Only the old row should be removed; the newer row survives.
+    val deleteTs = microsAtYear(2010)
+
+    val keysQueue = new mutable.Queue[RDD[Key]]()
+    keysQueue.enqueue(sc.parallelize(Seq(Key("old_row"), Key("future_row"))))
+
+    val stream = ssc.queueStream[Key](keysQueue)
+    stream.deleteFromCassandra(ks, "streaming_deletes_with_ts",
+      writeConf = WriteConf(timestamp = TimestampOption.constant(deleteTs)))
+
+    ssc.start()
+    eventually {
+      keysQueue shouldBe empty
+    }
+
+    eventually {
+      val result = ssc.cassandraTable[WordCount](ks, "streaming_deletes_with_ts").collect
+      result.length should be(1)
+      result(0) should be(WordCount("future_row", 2))
     }
   }
 }

--- a/connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
@@ -197,5 +197,222 @@ class TableWriterColumnNamesSpec extends SparkCassandraITAbstractSpecBase with D
 
       writer.queryTemplateUsingInsert should endWith (""") USING TIMESTAMP :timestamp_column""")
     }
+
+    "not include TTL or TIMESTAMP in delete when not specified" in {
+      val keyOnlyColumns: Seq[ColumnRef] = Seq("key", "group")
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = SomeColumns(keyOnlyColumns: _*),
+        writeConf = WriteConf(ttl = TTLOption.defaultValue, timestamp = TimestampOption.defaultValue)
+      )
+
+      val query = writer.deleteQueryTemplate(AllColumns)
+      query should not include "USING"
+      query should not include "TTL"
+      query should not include "TIMESTAMP"
+    }
+
+    "include TIMESTAMP in delete when static timestamp is specified" in {
+      val keyOnlyColumns: Seq[ColumnRef] = Seq("key", "group")
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = SomeColumns(keyOnlyColumns: _*),
+        writeConf = WriteConf(ttl = TTLOption.defaultValue, timestamp = TimestampOption.constant(1400000000000L))
+      )
+
+      val query = writer.deleteQueryTemplate(AllColumns)
+      query should include ("USING TIMESTAMP 1400000000000")
+      query should not include "TTL"
+    }
+
+    "include per-row TIMESTAMP in delete" in {
+      val keyOnlyColumns: Seq[ColumnRef] = Seq("key", "group")
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = SomeColumns(keyOnlyColumns: _*),
+        writeConf = WriteConf(ttl = TTLOption.defaultValue, timestamp = TimestampOption.perRow("timestamp_column"))
+      )
+
+      val query = writer.deleteQueryTemplate(AllColumns)
+      query should include ("USING TIMESTAMP :timestamp_column")
+      query should not include "TTL"
+    }
+
+    "ignore TTL in delete when only TTL is specified" in {
+      val keyOnlyColumns: Seq[ColumnRef] = Seq("key", "group")
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = SomeColumns(keyOnlyColumns: _*),
+        writeConf = WriteConf(ttl = TTLOption.constant(1234), timestamp = TimestampOption.defaultValue)
+      )
+
+      val query = writer.deleteQueryTemplate(AllColumns)
+      query should not include "TTL"
+      query should not include "USING"
+    }
+
+    "ignore TTL in delete and include only TIMESTAMP when both are specified" in {
+      val keyOnlyColumns: Seq[ColumnRef] = Seq("key", "group")
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = SomeColumns(keyOnlyColumns: _*),
+        writeConf = WriteConf(ttl = TTLOption.constant(1234), timestamp = TimestampOption.constant(1400000000000L))
+      )
+
+      val query = writer.deleteQueryTemplate(AllColumns)
+      query should not include "TTL"
+      query should include ("USING TIMESTAMP 1400000000000")
+    }
+
+    "include auto TIMESTAMP in update when no timestamp is specified" in {
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = AllColumns,
+        writeConf = WriteConf(ttl = TTLOption.defaultValue, timestamp = TimestampOption.defaultValue)
+      )
+
+      val query = writer.queryTemplateUsingUpdate
+      query should include (s"USING TIMESTAMP :${TableWriter.AutoTimestampParam}")
+      query should not include "TTL"
+    }
+
+    "include static TIMESTAMP in update when static timestamp is specified" in {
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = AllColumns,
+        writeConf = WriteConf(ttl = TTLOption.defaultValue, timestamp = TimestampOption.constant(1400000000000L))
+      )
+
+      val query = writer.queryTemplateUsingUpdate
+      query should include ("USING TIMESTAMP 1400000000000")
+      query should not include "TTL"
+    }
+
+    "include per-row TIMESTAMP in update" in {
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = AllColumns,
+        writeConf = WriteConf(ttl = TTLOption.defaultValue, timestamp = TimestampOption.perRow("timestamp_column"))
+      )
+
+      val query = writer.queryTemplateUsingUpdate
+      query should include ("USING TIMESTAMP :timestamp_column")
+      query should not include "TTL"
+    }
+
+    "include TTL and auto TIMESTAMP in update when only TTL is specified" in {
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = AllColumns,
+        writeConf = WriteConf(ttl = TTLOption.constant(1234), timestamp = TimestampOption.defaultValue)
+      )
+
+      val query = writer.queryTemplateUsingUpdate
+      query should include (s"USING TTL 1234 AND TIMESTAMP :${TableWriter.AutoTimestampParam}")
+    }
+
+    "include both TTL and static TIMESTAMP in update" in {
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = AllColumns,
+        writeConf = WriteConf(ttl = TTLOption.constant(1234), timestamp = TimestampOption.constant(1400000000000L))
+      )
+
+      val query = writer.queryTemplateUsingUpdate
+      query should include ("USING TTL 1234 AND TIMESTAMP 1400000000000")
+    }
+
+    "include per-row TTL and per-row TIMESTAMP in update" in {
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = AllColumns,
+        writeConf = WriteConf(ttl = TTLOption.perRow("ttl_column"), timestamp = TimestampOption.perRow("timestamp_column"))
+      )
+
+      val query = writer.queryTemplateUsingUpdate
+      query should include ("USING TTL :ttl_column AND TIMESTAMP :timestamp_column")
+    }
+
+    "ignore per-row TTL in delete" in {
+      val keyOnlyColumns: Seq[ColumnRef] = Seq("key", "group")
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = SomeColumns(keyOnlyColumns: _*),
+        writeConf = WriteConf(ttl = TTLOption.perRow("ttl_column"), timestamp = TimestampOption.defaultValue)
+      )
+
+      val query = writer.deleteQueryTemplate(SomeColumns())
+      query should not include "TTL"
+      query should not include "USING"
+    }
+
+    "ignore per-row TTL in delete and include only TIMESTAMP when both are specified" in {
+      val keyOnlyColumns: Seq[ColumnRef] = Seq("key", "group")
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = SomeColumns(keyOnlyColumns: _*),
+        writeConf = WriteConf(ttl = TTLOption.perRow("ttl_column"), timestamp = TimestampOption.constant(1400000000000L))
+      )
+
+      val query = writer.deleteQueryTemplate(SomeColumns())
+      query should not include "TTL"
+      query should include ("USING TIMESTAMP 1400000000000")
+    }
+
+    "reject regular columns as key columns for DELETE" in {
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = AllColumns,
+        writeConf = WriteConf()
+      )
+
+      val thrown = intercept[IllegalArgumentException] {
+        writer.deleteQueryTemplate(SomeColumns())
+      }
+      thrown.getMessage should include ("Regular columns found")
+    }
+
+    "generate column-level DELETE for AllColumns by filtering out primary key columns" in {
+      val keyOnlyColumns: Seq[ColumnRef] = Seq("key", "group")
+      val writer = TableWriter(
+        conn,
+        keyspaceName = ks,
+        tableName = "key_value",
+        columnNames = SomeColumns(keyOnlyColumns: _*),
+        writeConf = WriteConf()
+      )
+
+      val query = writer.deleteQueryTemplate(AllColumns)
+      query should startWith regex """DELETE "value" FROM"""
+      query should include ("WHERE")
+    }
   }
 }

--- a/connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -116,6 +116,15 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase with DefaultCluster {
         },
         Future {
           session.execute( s"""CREATE TABLE $ks.write_if_not_exists_test (id INT PRIMARY KEY, value TEXT)""")
+        },
+        Future {
+          session.execute( s"""CREATE TABLE $ks.delete_with_timestamp (key INT PRIMARY KEY, scol set<text>)""")
+        },
+        Future {
+          session.execute( s"""CREATE TABLE $ks.update_with_ttl (key INT PRIMARY KEY, scol set<text>, marker TEXT)""")
+        },
+        Future {
+          session.execute( s"""CREATE TABLE $ks.update_with_per_row_ttl (key INT PRIMARY KEY, scol set<text>, marker TEXT, ttl_col INT)""")
         }
       )
     }
@@ -422,6 +431,17 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase with DefaultCluster {
     val col = for (i <- 1 to rowCount) yield (i, 1)
     sc.parallelize(col).saveToCassandra(ks, "counters2", SomeColumns("pkey", "c"))
     sc.cassandraTable(ks, "counters2").cassandraCount() should be(rowCount)
+  }
+
+  it should "update counter table with TTL in WriteConf without error" in {
+    conn.withSessionDo(_.execute(s"""TRUNCATE $ks.counters2"""))
+    val col = Seq((1, 1))
+    sc.parallelize(col).saveToCassandra(ks, "counters2", SomeColumns("pkey", "c"),
+      writeConf = WriteConf(ttl = TTLOption.constant(100)))
+    conn.withSessionDo { session =>
+      val result = session.execute(s"""SELECT * FROM $ks.counters2""").one()
+      result.getLong("c") shouldEqual 1L
+    }
   }
 
   it should "write values of user-defined classes" in {
@@ -904,6 +924,80 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase with DefaultCluster {
     }
     e.getMessage should include("mcol")
     e.getMessage should include("scol")
+  }
+
+
+  it should "delete rows that were written with an older timestamp" in {
+    conn.withSessionDo(_.execute(s"""TRUNCATE $ks.delete_with_timestamp"""))
+
+    val setElements = sc.parallelize(Seq(
+      (1, Set("Four")),
+      (1, Set("Five")),
+      (1, Set("Six"))))
+    //Update data to year 1999
+    setElements.saveToCassandra(ks, "delete_with_timestamp", SomeColumns("key", "scol".append),
+      writeConf = WriteConf(timestamp = TimestampOption.constant(microsAtYear(1999))))
+
+    val newerElements = sc.parallelize(Seq(
+      (2, Set("Seven")),
+      (2, Set("Eight"))))
+    newerElements.saveToCassandra(ks, "delete_with_timestamp", SomeColumns("key", "scol".append),
+      writeConf = WriteConf(timestamp = TimestampOption.constant(microsAtYear(2020))))
+
+    // Try to delete rows older than year 2000.
+    sc.cassandraTable(ks, "delete_with_timestamp")
+      .deleteFromCassandra(ks, "delete_with_timestamp",
+        writeConf = WriteConf(timestamp = TimestampOption.constant(microsAtYear(2000))))
+
+    val result = sc.cassandraTable[(Int, Set[String])](ks, "delete_with_timestamp")
+      .select("key", "scol")
+      .collect()
+
+    result should contain theSameElementsAs Seq((2, Set("Seven", "Eight")))
+  }
+
+  it should "apply TTL to UPDATE when appending to a collection" in {
+    conn.withSessionDo(_.execute(s"""TRUNCATE $ks.update_with_ttl"""))
+
+    val setElements = sc.parallelize(Seq(
+      (1, Set("One"), "x"),
+      (1, Set("Two"), "x"),
+      (1, Set("Three"), "x")))
+
+    setElements.saveToCassandra(ks, "update_with_ttl", SomeColumns("key", "scol".append, "marker"),
+      writeConf = WriteConf(ttl = TTLOption.constant(300)))
+
+    // Verify TTL was applied using a regular column; SELECT TTL on collection columns
+    // is fragile across Scylla/Cassandra versions.
+    conn.withSessionDo { session =>
+      val row = session.execute(s"SELECT scol, TTL(marker) FROM $ks.update_with_ttl WHERE key = 1").one()
+      row.getSet("scol", classOf[String]).asScala.toSet should contain theSameElementsAs Set("One", "Two", "Three")
+      row.getInt(1) should be > 0
+    }
+  }
+
+  it should "apply per-row TTL to UPDATE when appending to a collection" in {
+    conn.withSessionDo(_.execute(s"""TRUNCATE $ks.update_with_per_row_ttl"""))
+
+    // Write rows with different per-row TTL values
+    val setElements = sc.parallelize(Seq(
+      (1, Set("A"), "x", 3600),
+      (2, Set("B"), "x", 600)))
+
+    setElements.saveToCassandra(ks, "update_with_per_row_ttl", SomeColumns("key", "scol".append, "marker"),
+      writeConf = WriteConf(ttl = TTLOption.perRow("ttl_col")))
+
+    // Verify different TTLs were applied using a regular column; SELECT TTL on collection
+    // columns is fragile across Scylla/Cassandra versions.
+    conn.withSessionDo { session =>
+      val row1 = session.execute(s"SELECT scol, TTL(marker) FROM $ks.update_with_per_row_ttl WHERE key = 1").one()
+      val row2 = session.execute(s"SELECT scol, TTL(marker) FROM $ks.update_with_per_row_ttl WHERE key = 2").one()
+      row1.getSet("scol", classOf[String]).asScala.toSet should contain theSameElementsAs Set("A")
+      row2.getSet("scol", classOf[String]).asScala.toSet should contain theSameElementsAs Set("B")
+      row1.getInt(1) should (be > 0 and be <= 3600)
+      row2.getInt(1) should (be > 0 and be <= 600)
+      row1.getInt(1) should be > (row2.getInt(1) + 2500)
+    }
   }
 
   it should "insert and not overwrite existing keys when ifNotExists is true" in {

--- a/connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -27,7 +27,7 @@ import com.datastax.spark.connector.rdd.partitioner.{CassandraPartitionedRDD, Re
 import com.datastax.spark.connector.rdd.reader._
 import com.datastax.spark.connector.rdd._
 import com.datastax.spark.connector.writer.{ReplicaLocator, _}
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag
@@ -131,14 +131,9 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
   implicit
     connector: CassandraConnector = CassandraConnector(sparkContext),
     rwf: RowWriterFactory[T]): Unit = {
-    // column delete require full primary key, partition key is enough otherwise
-    val columnDelete = deleteColumns match {
-      case c :SomeColumns => c.columns.nonEmpty
-      case _  => false
-    }
-
-    val writer = TableWriter(connector, keyspaceName, tableName, keyColumns, writeConf, !columnDelete)
-    rdd.sparkContext.runJob(rdd, writer.delete(deleteColumns) _)
+    val writer = TableWriter.forDelete(connector, keyspaceName, tableName, deleteColumns, keyColumns, writeConf)
+    val deleteFunc: (TaskContext, Iterator[T]) => Unit = writer.deleteRows _
+    rdd.sparkContext.runJob(rdd, deleteFunc)
   }
 
   /** Applies a function to each item, and groups consecutive items having the same value together.

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/CasssandraDriverDataWriterFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/CasssandraDriverDataWriterFactory.scala
@@ -56,7 +56,8 @@ case class CassandraDriverDataWriter(
   private val columns = SomeColumns(inputSchema.fieldNames.map(name => ColumnName(name)): _*)
 
   private val writer =
-    TableWriter(connector, tableDef, columns, writeConf, false, partitions = Array(), None)(unsafeRowWriterFactory)
+    TableWriter(connector, tableDef, columns, writeConf, false,
+      partitions = Array(), tokenRangeAcc = None, isDelete = false)(unsafeRowWriterFactory)
       .getAsyncWriter()
 
   override def write(record: InternalRow): Unit = writer.write(record)

--- a/connector/src/main/scala/com/datastax/spark/connector/streaming/DStreamFunctions.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/streaming/DStreamFunctions.scala
@@ -25,7 +25,7 @@ import com.datastax.spark.connector.rdd.ValidRDDType
 import com.datastax.spark.connector.rdd.reader.RowReaderFactory
 import com.datastax.spark.connector.util.Logging
 import com.datastax.spark.connector.writer._
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkContext, TaskContext}
 import org.apache.spark.streaming.Duration
 import org.apache.spark.streaming.dstream.DStream
 
@@ -88,13 +88,9 @@ class DStreamFunctions[T](dstream: DStream[T])
     connector: CassandraConnector = CassandraConnector(sparkContext),
     rwf: RowWriterFactory[T]): Unit = {
 
-    // column delete require full primary key, partition key is enough otherwise
-    val columnDelete = deleteColumns match {
-      case c :SomeColumns => c.columns.nonEmpty
-      case _  => false
-    }
-    val writer = TableWriter(connector, keyspaceName, tableName, keyColumns, writeConf, !columnDelete)
-    dstream.foreachRDD(rdd => rdd.sparkContext.runJob(rdd, writer.delete(deleteColumns) _))
+    val writer = TableWriter.forDelete(connector, keyspaceName, tableName, deleteColumns, keyColumns, writeConf)
+    val deleteFunc: (TaskContext, Iterator[T]) => Unit = writer.deleteRows _
+    dstream.foreachRDD(rdd => rdd.sparkContext.runJob(rdd, deleteFunc))
   }
 
   /**

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
@@ -44,6 +44,7 @@ private[connector] class BoundStatementBuilder[T](
   private val variableDefinitions = preparedStmt.getVariableDefinitions
 
   /** Precomputed variable indices for each column in the prepared statement.
+    * Empty for columns not present in the row-bound part of the statement (option placeholders).
     * A column name can occur more than once when a real column is also used as
     * a per-row TTL/TIMESTAMP placeholder; bind every occurrence by index so
     * each marker uses its own CQL type and is included in size accounting.
@@ -63,8 +64,10 @@ private[connector] class BoundStatementBuilder[T](
   private val cachedCodecs = columnTypes.map(types => new Array[TypeCodec[AnyRef]](types.length))
 
   /** Internal auto-timestamp placeholder to bind, if this statement was generated with one. */
-  private val autoTimestampVariable: Option[String] =
-    autoTimestampParam.filter(preparedStmt.getVariableDefinitions.contains)
+  private val autoTimestampIndices: Array[Int] =
+    autoTimestampParam
+      .map(variableIndicesFor)
+      .getOrElse(Array.emptyIntArray)
 
   /** Monotonically incrementing microsecond counter for auto-timestamps.
     * Uses a global counter to guarantee uniqueness across all concurrent
@@ -168,8 +171,8 @@ private[connector] class BoundStatementBuilder[T](
       }
     }
 
-    autoTimestampVariable.foreach { param =>
-      boundStatement.update(_.setLong(param, autoTsCounter.getAndIncrement()))
+    autoTimestampIndices.foreach { index =>
+      boundStatement.update(_.setLong(index, autoTsCounter.getAndIncrement()))
       bytesCount += 8 // Long = 8 bytes, not counted in the column loop above
     }
 
@@ -184,7 +187,16 @@ private[connector] object BoundStatementBuilder {
     * BoundStatementBuilder instances in the JVM. Ensures that every bound
     * statement gets a unique timestamp even when multiple Spark tasks bind
     * concurrently. Initialized to the current wall-clock time in microseconds
-    * so that timestamps stay in the same ballpark as server-assigned ones. */
+    * so that timestamps stay in the same ballpark as server-assigned ones.
+    *
+    * Known limitations:
+    * - JVM restart (OOM, preemption, speculative execution) may initialize
+    *   a new counter below the previous JVM's last used value. This is
+    *   acceptable because the auto-timestamp only needs to order mutations
+    *   within a single batch to avoid list-mutation deduplication (issue #26);
+    *   cross-JVM ordering relies on CQL last-write-wins semantics.
+    * - Overflow is not a practical concern: at ~1.7e15 microseconds since
+    *   epoch, Long.MaxValue (~9.2e18) provides ~584 years of headroom. */
   private[writer] val globalAutoTsCounter =
     new java.util.concurrent.atomic.AtomicLong(System.currentTimeMillis() * 1000)
 

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -21,7 +21,7 @@ package com.datastax.spark.connector.writer
 import java.io.{Closeable, IOException}
 import java.util.function.Supplier
 
-import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.{CqlIdentifier, CqlSession}
 import com.datastax.oss.driver.api.core.cql.{DefaultBatchType, PreparedStatement, SimpleStatement}
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql._
@@ -34,6 +34,7 @@ import org.apache.spark.{Partition, TaskContext}
 import org.apache.spark.metrics.OutputMetricsUpdater
 
 import scala.collection._
+import scala.util.control.NonFatal
 
 /** Writes RDD data into given Cassandra table.
   * Individual column values are extracted from RDD objects using given [[RowWriter]]
@@ -46,34 +47,43 @@ class TableWriter[T] private (
     rowWriter: RowWriter[T],
     writeConf: WriteConf,
     partitions: Array[Partition],
-    tokenRangeAcc: Option[TokenRangeAccumulator]) extends Serializable with Logging {
+    tokenRangeAcc: Option[TokenRangeAccumulator],
+    private val isDelete: Boolean = false,
+    private var cachedDeleteQueryTemplate: Option[String] = None,
+    syntheticColumnNames: Set[String] = Set.empty,
+    autoAddedOptionColumnNames: Set[String] = Set.empty) extends Serializable with Logging {
 
   require(!tableDef.isView,
     s"${tableDef.name} is a Materialized View and Views are not writable")
 
   val keyspaceName = tableDef.keyspaceName
   val tableName = tableDef.tableName
-  val columnNames = rowWriter.columnNames diff writeConf.optionPlaceholders
+  private val deleteOptionColumnNames =
+    if (isDelete) TableWriter.nonPrimaryKeyOptionPlaceholders(tableDef, writeConf) else Set.empty[String]
+  private val bindOnlyColumnNames = syntheticColumnNames ++ autoAddedOptionColumnNames ++ deleteOptionColumnNames
+  val columnNames = rowWriter.columnNames.filterNot(bindOnlyColumnNames.contains)
   val columns = columnNames.map(tableDef.columnByName)
 
+  private lazy val tableDefWithoutPlaceholders: TableDef =
+    if (syntheticColumnNames.isEmpty) tableDef
+    else tableDef.copy(
+      regularColumns = tableDef.regularColumns.filterNot(c => syntheticColumnNames.contains(c.columnName))
+    )
+
   private[connector] lazy val queryTemplateUsingInsert: String = {
+    val rowWriterColumnNames = rowWriter.columnNames.toSet
+    val unboundOptionPlaceholders = writeConf.optionPlaceholders.filterNot(rowWriterColumnNames.contains)
+    if (unboundOptionPlaceholders.nonEmpty) {
+      throw new IllegalArgumentException(
+        s"INSERT uses per-row write option placeholder(s) that are not selected from the input row: " +
+          s"${unboundOptionPlaceholders.mkString(", ")}. Add the placeholder column(s) to the column selector or use AllColumns.")
+    }
+
     val quotedColumnNames: Seq[String] = columnNames.map(quote)
     val columnSpec = quotedColumnNames.mkString(", ")
     val valueSpec = quotedColumnNames.map(":" + _).mkString(", ")
 
     val ifNotExistsSpec = if (writeConf.ifNotExists) "IF NOT EXISTS " else ""
-
-    val ttlSpec = writeConf.ttl match {
-      case TTLOption(PerRowWriteOptionValue(placeholder)) => Some(s"""TTL :$placeholder""")
-      case TTLOption(StaticWriteOptionValue(value)) => Some(s"TTL $value")
-      case _ => None
-    }
-
-    val timestampSpec = writeConf.timestamp match {
-      case TimestampOption(PerRowWriteOptionValue(placeholder)) => Some(s"""TIMESTAMP :$placeholder""")
-      case TimestampOption(StaticWriteOptionValue(value)) => Some(s"TIMESTAMP $value")
-      case _ => None
-    }
 
     val options = List(ttlSpec, timestampSpec).flatten
     val optionsSpec = if (options.nonEmpty) s"USING ${options.mkString(" AND ")}" else ""
@@ -81,22 +91,92 @@ class TableWriter[T] private (
     s"INSERT INTO ${quote(keyspaceName)}.${quote(tableName)} ($columnSpec) VALUES ($valueSpec) $ifNotExistsSpec$optionsSpec".trim
   }
 
-  private def deleteQueryTemplate(deleteColumns: ColumnSelector): String = {
-    val deleteColumnNames: Seq[String] = deleteColumns.selectFrom(tableDef).map(_.columnName)
-    val (primaryKey, regularColumns) = columns.partition(_.isPrimaryKeyColumn)
+  // A `def` because `deleteColumns` is a parameter, not a property of the writer.
+  // Called once by `TableWriter.forDelete` which caches the result in `cachedDeleteQueryTemplate`.
+  // Precondition: `columns` (the key columns for the WHERE clause) must contain only primary key
+  // columns. This is enforced by the caller (RDDFunctions.deleteFromCassandra passes PK-only
+  // columns), and validated by the primary-key-only check below.
+  private[writer] def deleteQueryTemplate(deleteColumns: ColumnSelector): String = {
+    // CQL DELETE supports deleting an entire collection column, but not collection-element
+    // write operations (append, prepend, remove).
+    deleteColumns match {
+      case sc: SomeColumns =>
+        val collectionRefs = sc.columns.collect {
+          case c: CollectionColumnName if c.collectionBehavior != CollectionOverwrite => c.columnName
+        }
+        if (collectionRefs.nonEmpty) {
+          throw new IllegalArgumentException(
+            s"CQL DELETE does not support collection behaviors. Collection columns found in delete columns: ${collectionRefs.mkString(", ")}")
+        }
+      case _ => // AllColumns, PrimaryKeyColumns, etc. never produce CollectionColumnName
+    }
+
+    // Validate column existence before selectFrom to give a DELETE-specific error message.
+    // selectFrom throws a generic NoSuchElementException that doesn't mention DELETE.
+    deleteColumns match {
+      case sc: SomeColumns =>
+        val tableColumnNames = tableDefWithoutPlaceholders.columns.map(_.columnName).toSet
+        val missing = sc.columns.map(_.columnName).filterNot(tableColumnNames.contains)
+        if (missing.nonEmpty)
+          throw new IllegalArgumentException(
+            s"Column(s) not found for DELETE in table ${tableDef.tableName}: ${missing.mkString(", ")}")
+      case _ =>
+    }
+
+    val primaryKeyNames = tableDef.primaryKey.map(_.columnName).toSet
+    // selectFrom uses tableDefWithoutPlaceholders so that synthetic option-placeholder columns are excluded
+    val allDeleteColumnNames: Seq[String] = deleteColumns.selectFrom(tableDefWithoutPlaceholders).map(_.columnName)
+    // When AllColumns is used, auto-filter primary key columns since they can't be deleted
+    val deleteColumnNames = if (deleteColumns == AllColumns) {
+      val filtered = allDeleteColumnNames.filterNot(primaryKeyNames.contains)
+      if (filtered.isEmpty)
+        logInfo(s"Table ${tableDef.tableName} has no non-PK columns; AllColumns delete will perform a full-row delete")
+      filtered
+    } else {
+      allDeleteColumnNames
+    }
+    val deleteKeyColumns = columns.filterNot { col =>
+      TableWriter.nonPrimaryKeyOptionPlaceholders(tableDef, writeConf).contains(col.columnName)
+    }
+    val (primaryKey, regularColumns) = deleteKeyColumns.partition(_.isPrimaryKeyColumn)
     if (regularColumns.nonEmpty) {
       throw new IllegalArgumentException(
-        s"Only primary key columns can be used in delete. Regular columns found: ${regularColumns.mkString(", ")}")
+        s"Only primary key columns can be specified as key columns for DELETE. Regular columns found: ${regularColumns.mkString(", ")}")
     }
-    TableWriter.checkMissingColumns(tableDef, deleteColumnNames)
-
+    // Empty deleteColumnNames = full row delete; PK column check only applies to column-level deletes
+    if (deleteColumnNames.nonEmpty) {
+      val pkInDelete = deleteColumnNames.filter(primaryKeyNames.contains)
+      if (pkInDelete.nonEmpty) {
+        throw new IllegalArgumentException(
+          s"Primary key columns cannot be specified as delete columns. Primary key columns found: ${pkInDelete.mkString(", ")}")
+      }
+    }
     def quotedColumnNames(columns: Seq[ColumnDef]) = columns.map(_.columnName).map(quote)
     val deleteColumnsClause = deleteColumnNames.map(quote).mkString(", ")
-    val whereClause = quotedColumnNames(primaryKey).map(c => s"$c = :$c").mkString(" AND ")
+    val deleteColumnDefs = deleteColumnNames.map(tableDef.columnByName)
+    if (deleteColumnDefs.exists(col => !col.isStatic)) {
+      val selectedPrimaryKeyNames = primaryKey.map(_.columnName).toSet
+      val missingPrimaryKeyNames = tableDef.primaryKey.map(_.columnName).filterNot(selectedPrimaryKeyNames.contains)
+      if (missingPrimaryKeyNames.nonEmpty) {
+        throw new IllegalArgumentException(
+          s"Deleting non-static columns requires the full primary key. " +
+            s"Missing primary key columns: ${missingPrimaryKeyNames.mkString(", ")}")
+      }
+    }
+    val whereColumns =
+      if (deleteColumnDefs.nonEmpty && deleteColumnDefs.forall(_.isStatic))
+        primaryKey.filter(_.isPartitionKeyColumn)
+      else
+        primaryKey
+    val whereClause = quotedColumnNames(whereColumns).map(c => s"$c = :$c").mkString(" AND ")
 
-    s"DELETE ${deleteColumnsClause} FROM ${quote(keyspaceName)}.${quote(tableName)} WHERE $whereClause"
+    val usingTimestampClause = timestampSpec.map(ts => s" USING $ts").getOrElse("")
+    val deleteSpec = if (deleteColumnsClause.nonEmpty) s"$deleteColumnsClause " else ""
+
+    s"DELETE ${deleteSpec}FROM ${quote(keyspaceName)}.${quote(tableName)}$usingTimestampClause WHERE $whereClause"
   }
-  private lazy val queryTemplateUsingUpdate: String = {
+
+  private[writer] lazy val queryTemplateUsingUpdate: String = {
     val (primaryKey, regularColumns) = columns.partition(_.isPrimaryKeyColumn)
     val (counterColumns, nonCounterColumns) = regularColumns.partition(_.isCounterColumn)
 
@@ -121,25 +201,47 @@ class TableWriter[T] private (
     val setClause = (setNonCounterColumnsClause ++ setCounterColumnsClause).mkString(", ")
     val whereClause = quotedColumnNames(primaryKey).map(c => s"$c = :$c").mkString(" AND ")
 
-    // Counter updates don't support USING TIMESTAMP.
+    // Counter updates don't support USING TIMESTAMP or USING TTL.
     // For all other UPDATEs, assign per-statement timestamps to ensure that multiple
     // mutations to the same list within a batch get distinct timestamps. Without this,
     // Scylla drops all but one list mutation when they share the same timestamp.
     // See: https://github.com/scylladb/spark-scylladb-connector/issues/26
+    // Note: TTL is now also applied to UPDATE statements when writeConf.ttl is set.
+    // Previously TTL was only included in INSERT statements.
     val usingClause = if (isCounterUpdate) {
       ""
     } else {
-      writeConf.timestamp match {
-        case TimestampOption(PerRowWriteOptionValue(placeholder)) => s" USING TIMESTAMP :$placeholder"
-        case TimestampOption(StaticWriteOptionValue(value)) => s" USING TIMESTAMP $value"
-        case _ =>
-          TableWriter.checkAutoTimestampCollisions(columnNames, writeConf)
-          s" USING TIMESTAMP :${TableWriter.AutoTimestampParam}"
+      val autoTs = if (usesAutoTimestampForUpdate) {
+        TableWriter.checkAutoTimestampCollisions(columnNames, writeConf)
+        Some(s"TIMESTAMP :${TableWriter.AutoTimestampParam}")
+      } else {
+        None
       }
+      val parts = List(ttlSpec, timestampSpec.orElse(autoTs)).flatten
+      if (parts.nonEmpty) s" USING ${parts.mkString(" AND ")}" else ""
     }
 
     s"UPDATE ${quote(keyspaceName)}.${quote(tableName)}${usingClause} SET $setClause WHERE $whereClause"
   }
+
+  private lazy val timestampSpec: Option[String] = {
+    writeConf.timestamp match {
+      case TimestampOption(PerRowWriteOptionValue(placeholder)) => Some(s"TIMESTAMP ${optionBindMarker(placeholder)}")
+      case TimestampOption(StaticWriteOptionValue(value)) => Some(s"TIMESTAMP $value")
+      case _ => None
+    }
+  }
+
+  private lazy val ttlSpec: Option[String] = {
+    writeConf.ttl match {
+      case TTLOption(PerRowWriteOptionValue(placeholder)) => Some(s"TTL ${optionBindMarker(placeholder)}")
+      case TTLOption(StaticWriteOptionValue(value)) => Some(s"TTL $value")
+      case _ => None
+    }
+  }
+
+  private def optionBindMarker(placeholder: String): String =
+    s":${CqlIdentifier.fromInternal(placeholder).asCql(true)}"
 
   private val isCounterUpdate =
     tableDef.columns.exists(_.isCounterColumn)
@@ -148,11 +250,14 @@ class TableWriter[T] private (
     columnSelector.exists(_.isInstanceOf[CollectionColumnName])
 
   private lazy val usesAutoTimestampForUpdate: Boolean =
-    !isCounterUpdate && writeConf.timestamp == TimestampOption.defaultValue
+    !isCounterUpdate && timestampSpec.isEmpty
 
-  private[connector] val isIdempotent: Boolean = {
+  private[connector] lazy val isIdempotent: Boolean = {
+    // DELETEs are inherently idempotent
+    if (isDelete) {
+      true
     //All counter operations are not Idempotent
-    if (columns.exists(_.isCounterColumn)) {
+    } else if (columns.exists(_.isCounterColumn)) {
        false
     } else {
       columnSelector.forall {
@@ -172,9 +277,14 @@ class TableWriter[T] private (
     }
   }
 
-  private def prepareStatement(queryTemplate:String, session: CqlSession): PreparedStatement = {
+  private def prepareStatement(
+      queryTemplate:String,
+      session: CqlSession,
+      idempotent: Boolean): PreparedStatement = {
     try {
       val stmt = SimpleStatement.newInstance(queryTemplate)
+        .setIdempotent(idempotent)
+        .setConsistencyLevel(writeConf.consistencyLevel)
       session.prepare(stmt)
     }
     catch {
@@ -205,18 +315,27 @@ class TableWriter[T] private (
     * INSERT otherwise
     */
   def write(taskContext: TaskContext, data: Iterator[T]): Unit = {
+    require(!isDelete, "write() must not be called on a delete-configured TableWriter; use delete() instead")
     val asyncStatementWriter = getAsyncWriter()
     writeInternal(asyncStatementWriter, taskContext, data)
   }
 
   /**
-    * Cql DELETE statement
-    * @param columns columns to delete, the row will be deleted completely if the list is empty
-    * @param taskContext
-    * @param data primary key values to select delete rows
+    * Cql DELETE statement. The writer must be created via [[TableWriter.forDelete]] which
+    * eagerly validates and caches the delete query template.
     */
-  def delete(columns: ColumnSelector) (taskContext: TaskContext, data: Iterator[T]): Unit =
-    writeInternal(getAsyncWriterInternal(deleteQueryTemplate(columns)), taskContext, data)
+  private[connector] def deleteRows(taskContext: TaskContext, data: Iterator[T]): Unit = {
+    val template = cachedDeleteQueryTemplate.getOrElse(
+      throw new IllegalStateException(
+        "deleteRows() requires a cached delete query template; create the writer with TableWriter.forDelete()"))
+    writeInternal(getAsyncWriterInternal(template), taskContext, data)
+  }
+
+  /** Compatibility entry point for callers that construct a TableWriter directly
+    * and pass delete columns at call time. Prefer [[TableWriter.forDelete]] for
+    * new code so DELETE validation happens before the Spark job is submitted. */
+  def delete(columns: ColumnSelector)(taskContext: TaskContext, data: Iterator[T]): Unit =
+    writeInternal(getAsyncWriterInternal(deleteQueryTemplate(columns), isDeleteStatement = true), taskContext, data)
 
   def extractTokenRange(partitionId: Int): Iterable[CqlTokenRange[_, _]] =
     partitions.lift(partitionId) match {
@@ -225,6 +344,7 @@ class TableWriter[T] private (
     }
 
   def getAsyncWriter(): AsyncStatementWriter[T] = {
+    require(!isDelete, "getAsyncWriter() must not be called on a delete-configured TableWriter; use delete() instead")
     if (isCounterUpdate || containsCollectionBehaviors) {
       getAsyncWriterInternal(
         queryTemplateUsingUpdate,
@@ -237,10 +357,14 @@ class TableWriter[T] private (
 
   private def getAsyncWriterInternal(
       queryTemplate: String,
-      autoTimestampParam: Option[String] = None): AsyncStatementWriter[T] = {
+      autoTimestampParam: Option[String] = None,
+      isDeleteStatement: Boolean = false): AsyncStatementWriter[T] = {
     connector.withSessionDo { session =>
       val protocolVersion = session.getContext.getProtocolVersion
-      val stmt = prepareStatement(queryTemplate, session)
+      val deleteStatement = isDelete || isDeleteStatement
+      val statementIdempotent = if (deleteStatement) true else isIdempotent
+      val stmt = prepareStatement(queryTemplate, session,
+        idempotent = statementIdempotent)
       val batchType = if (isCounterUpdate) DefaultBatchType.COUNTER else DefaultBatchType.UNLOGGED
 
       val boundStmtBuilder = new BoundStatementBuilder(
@@ -253,7 +377,7 @@ class TableWriter[T] private (
       val batchStmtBuilder = new BatchStatementBuilder(
         batchType,
         writeConf.consistencyLevel,
-        isIdempotent)
+        statementIdempotent)
       val batchKeyGenerator = batchRoutingKey(session)
       val batchBuilder = new GroupingBatchBuilderBase(boundStmtBuilder, batchStmtBuilder, batchKeyGenerator,
         writeConf.batchSize, writeConf.batchGroupingBufferSize)
@@ -358,6 +482,10 @@ object TableWriter {
       throw new IllegalArgumentException(
         s"Selected column '$AutoTimestampParam' conflicts with internal auto-timestamp parameter. " +
         "Rename the column or use an explicit timestamp via WriteConf.")
+    checkOptionPlaceholderCollisions(writeConf)
+  }
+
+  private def checkOptionPlaceholderCollisions(writeConf: WriteConf): Unit = {
     if (writeConf.optionPlaceholders.contains(AutoTimestampParam))
       throw new IllegalArgumentException(
         s"Per-row placeholder name '$AutoTimestampParam' conflicts with internal auto-timestamp parameter.")
@@ -455,12 +583,21 @@ object TableWriter {
       )
   }
 
-  private def checkColumns(table: TableDef, columnRefs: IndexedSeq[ColumnRef], checkPartitionKey: Boolean) = {
+  private def checkColumns(
+      table: TableDef,
+      columnRefs: IndexedSeq[ColumnRef],
+      partitionKeyOnly: Boolean,
+      isDelete: Boolean) = {
     val columnNames = columnRefs.map(_.columnName)
     checkMissingColumns(table, columnNames)
-    if (checkPartitionKey) {
+    if (partitionKeyOnly) {
       // For Deletes we only need a partition Key for a valid delete statement
       checkMissingPartitionKeyColumns(table, columnNames)
+    }
+    else if (isDelete) {
+      // Non-static column deletes require a full primary key. The write-side static-column
+      // exception below does not apply because delete columns are passed separately.
+      checkMissingPrimaryKeyColumns(table, columnNames)
     }
     else if (onlyPartitionKeyAndStatic(table, columnNames)) {
       // Cassandra only requires a Partition Key Column on insert if all other columns are Static
@@ -473,7 +610,166 @@ object TableWriter {
     checkCollectionBehaviors(table, columnRefs)
   }
 
-  /** Columns that cannot actually be written to because they representt virtual endpoints
+  private[writer] def isColumnDelete(table: TableDef, deleteColumns: ColumnSelector): Boolean = deleteColumns match {
+    case c: SomeColumns =>
+      c.columns.exists(col => table.columnByName.get(col.columnName).exists { colDef =>
+        !colDef.isPrimaryKeyColumn && !colDef.isStatic
+      })
+    case AllColumns =>
+      table.regularColumns.exists(col => !col.isStatic)
+    case _ => false
+  }
+
+  private[writer] def validateDeleteSelectors(
+      tableDef: TableDef,
+      deleteColumns: ColumnSelector,
+      keyColumns: ColumnSelector): Unit = {
+    keyColumns match {
+      case AllColumns if tableDef.regularColumns.nonEmpty =>
+        throw new IllegalArgumentException(
+          "AllColumns cannot be used as keyColumns for DELETE when the table has non-primary-key columns; " +
+          "use PrimaryKeyColumns or SomeColumns(...)")
+      case _ =>
+    }
+    deleteColumns match {
+      case PrimaryKeyColumns | PartitionKeyColumns =>
+        throw new IllegalArgumentException(
+          s"$deleteColumns cannot be used as deleteColumns for DELETE; " +
+          "use SomeColumns(...) to delete specific columns or SomeColumns() for full-row delete")
+      case _ =>
+    }
+  }
+
+  private[writer] def nonPrimaryKeyOptionPlaceholders(tableDef: TableDef, writeConf: WriteConf): Set[String] =
+    writeConf.optionPlaceholders.filterNot { name =>
+      tableDef.columnByName.get(name).exists(_.isPrimaryKeyColumn)
+    }.toSet
+
+  private class FallbackRowWriter[T](primary: RowWriter[T], fallback: RowWriter[T]) extends RowWriter[T] {
+
+    override val columnNames: scala.collection.immutable.Seq[String] = primary.columnNames
+
+    private val fallbackColumnNames = fallback.columnNames.toIndexedSeq
+    private val fallbackBuffer = Array.ofDim[Any](fallbackColumnNames.size)
+    private val primaryIndexByName = columnNames.zipWithIndex.toMap
+    private val copyPlan = fallbackColumnNames.zipWithIndex.map { case (columnName, fallbackIndex) =>
+      fallbackIndex -> primaryIndexByName(columnName)
+    }
+
+    override def readColumnValues(data: T, buffer: Array[Any]): Unit = {
+      try {
+        primary.readColumnValues(data, buffer)
+      } catch {
+        case NonFatal(primaryFailure) =>
+          try {
+            fallback.readColumnValues(data, fallbackBuffer)
+            copyPlan.foreach { case (fallbackIndex, primaryIndex) =>
+              buffer(primaryIndex) = fallbackBuffer(fallbackIndex)
+            }
+          } catch {
+            case NonFatal(_) => throw primaryFailure
+          }
+      }
+    }
+  }
+
+  private def rowWriterWith[T](
+      rowWriterFactory: RowWriterFactory[T],
+      tableDefWithMeta: TableDef,
+      optionColumns: Seq[ColumnDef],
+      selectedColumns: scala.collection.immutable.IndexedSeq[ColumnRef],
+      bindOnlyColumnNames: Set[String]): RowWriter[T] = {
+    // Bind-only option placeholders should be extracted with TTL/TIMESTAMP types,
+    // even when their names match real table columns.
+    val bindOnlyOptionColumnsByName = optionColumns
+      .filter(c => bindOnlyColumnNames.contains(c.columnName))
+      .map(c => c.columnName -> c)
+      .toMap
+    val tableDefForRowWriter =
+      if (bindOnlyOptionColumnsByName.isEmpty) {
+        tableDefWithMeta
+      } else {
+        tableDefWithMeta.copy(regularColumns = tableDefWithMeta.regularColumns.map { column =>
+          bindOnlyOptionColumnsByName.getOrElse(column.columnName, column)
+        })
+      }
+    rowWriterFactory.rowWriter(tableDefForRowWriter, selectedColumns)
+  }
+
+  private def rowWriterSelection[T](
+      rowWriterFactory: RowWriterFactory[T],
+      tableDefWithMeta: TableDef,
+      optionColumns: Seq[ColumnDef],
+      selectedColumns: scala.collection.immutable.IndexedSeq[ColumnRef],
+      syntheticColumnNames: Set[String],
+      autoAddedOptionColumnNames: Set[String],
+      deleteOptionColumnNames: Set[String],
+      retryWithoutIgnoredDeleteTtl: Option[String]):
+      (scala.collection.immutable.IndexedSeq[ColumnRef], Set[String], RowWriter[T]) = {
+
+    def build(
+        selectedColumns: scala.collection.immutable.IndexedSeq[ColumnRef],
+        autoAddedOptionColumnNames: Set[String]) = {
+      val bindOnlyColumnNames = syntheticColumnNames ++ autoAddedOptionColumnNames ++ deleteOptionColumnNames
+      rowWriterWith(rowWriterFactory, tableDefWithMeta, optionColumns, selectedColumns, bindOnlyColumnNames)
+    }
+
+    retryWithoutIgnoredDeleteTtl match {
+      case Some(ttlPlaceholder) =>
+        // DELETE ignores TTL. Keep the ignored TTL field when it exists to preserve tuple
+        // positions, but do not require named row types to define it.
+        val selectedWithoutIgnoredTtl = selectedColumns.filterNot(_.columnName == ttlPlaceholder)
+        val autoAddedWithoutIgnoredTtl = autoAddedOptionColumnNames - ttlPlaceholder
+        try {
+          val primary = build(selectedColumns, autoAddedOptionColumnNames)
+          val rowWriter = try {
+            new FallbackRowWriter(primary, build(selectedWithoutIgnoredTtl, autoAddedWithoutIgnoredTtl))
+          } catch {
+            case NonFatal(_) => primary
+          }
+          (selectedColumns, autoAddedOptionColumnNames, rowWriter)
+        } catch {
+          case NonFatal(original) =>
+            try {
+              (selectedWithoutIgnoredTtl, autoAddedWithoutIgnoredTtl,
+                build(selectedWithoutIgnoredTtl, autoAddedWithoutIgnoredTtl))
+            } catch {
+              case NonFatal(_) => throw original
+            }
+        }
+      case None =>
+        (selectedColumns, autoAddedOptionColumnNames, build(selectedColumns, autoAddedOptionColumnNames))
+    }
+  }
+
+  /** Creates a [[TableWriter]] configured for DELETE operations.
+    * Determines whether this is a column-level or full-row delete, adjusts the
+    * [[WriteConf]] (stripping TTL and other INSERT-only options), and constructs
+    * the writer with the appropriate key-column validation mode.
+    * Eagerly validates the delete query template on the driver to fail fast
+    * rather than wasting cluster resources on executor-side validation. */
+  private[connector] def forDelete[T : RowWriterFactory](
+      connector: CassandraConnector,
+      keyspaceName: String,
+      tableName: String,
+      deleteColumns: ColumnSelector,
+      keyColumns: ColumnSelector,
+      writeConf: WriteConf): TableWriter[T] = {
+    val tableDef = tableFromCassandra(connector, keyspaceName, tableName)
+    validateDeleteSelectors(tableDef, deleteColumns, keyColumns)
+    // Column delete requires full primary key; partition key is enough otherwise.
+    val columnDelete = isColumnDelete(tableDef, deleteColumns)
+    val deleteConf = writeConf.forDelete
+    val writer = TableWriter[T](connector, tableDef, keyColumns, deleteConf,
+      partitionKeyOnly = !columnDelete, partitions = Array(), tokenRangeAcc = None, isDelete = true)
+    // Eagerly compute and cache the delete query template on the driver side.
+    // This triggers all validation (column existence, PK checks, collection checks)
+    // before the Spark job is submitted, avoiding wasted cluster resources.
+    writer.cachedDeleteQueryTemplate = Some(writer.deleteQueryTemplate(deleteColumns))
+    writer
+  }
+
+  /** Columns that cannot actually be written to because they represent virtual endpoints
     */
   private val InternalColumns = Set("solr_query")
 
@@ -500,24 +796,89 @@ object TableWriter {
        partitions: Array[Partition],
        tokenRangeAcc: Option[TokenRangeAccumulator]): TableWriter[T] = {
 
+    TableWriter(connector, tableDef, columnNames, writeConf, checkPartitionKey, partitions, tokenRangeAcc, isDelete = false)
+  }
+
+  def apply[T : RowWriterFactory](
+       connector: CassandraConnector,
+       tableDef: TableDef,
+       columnNames: ColumnSelector,
+       writeConf: WriteConf,
+       partitionKeyOnly: Boolean,
+       partitions: Array[Partition],
+       tokenRangeAcc: Option[TokenRangeAccumulator],
+       isDelete: Boolean): TableWriter[T] = {
+
     val optionColumns = writeConf.optionsAsColumns(tableDef.keyspaceName, tableDef.tableName)
     val tableHasCounterColumns = tableDef.columns.exists(_.isCounterColumn)
-    val tablDefWithMeta = tableDef.copy(regularColumns = tableDef.regularColumns ++ optionColumns)
-
-    val tableDefForSelection = if (tableHasCounterColumns && columnNames == AllColumns) {
+    val candidateAutoSelectedOptionColumns = if (isDelete) {
+      (writeConf.ttl, writeConf.timestamp) match {
+        case (TTLOption(PerRowWriteOptionValue(_)), TimestampOption(PerRowWriteOptionValue(_))) =>
+          // DELETE never binds TTL, but when a per-row timestamp follows it in a tuple,
+          // keep the ignored TTL placeholder selected so tuple positions do not shift.
+          optionColumns
+        case (TTLOption(PerRowWriteOptionValue(ttlPlaceholder)), _) =>
+          // TTL-only DELETEs should not require an ignored placeholder when omitted.
+          optionColumns.filterNot(_.columnName == ttlPlaceholder)
+        case _ => optionColumns
+      }
+    } else if (tableHasCounterColumns) {
       // Counter UPDATE statements do not support TTL or TIMESTAMP, so per-row
       // placeholders must not be required unless the caller selected them explicitly.
-      tableDef
+      Seq.empty
     } else {
-      tablDefWithMeta
+      optionColumns
     }
+    val existingColumnNames = tableDef.columns.map(_.columnName).toSet
+    val newOptionColumns = optionColumns.filterNot(c => existingColumnNames.contains(c.columnName))
+    val syntheticColumnNames = newOptionColumns.map(_.columnName).toSet
+    val tablDefWithMeta = tableDef.copy(regularColumns = tableDef.regularColumns ++ newOptionColumns)
 
-    val selectedColumns = columnNames
+    val candidateAutoSelectedOptionColumnNames = candidateAutoSelectedOptionColumns.map(_.columnName).toSet
+    val selectableOptionColumns = columnNames match {
+      case AllColumns => newOptionColumns.filter(c => candidateAutoSelectedOptionColumnNames.contains(c.columnName))
+      case _ => newOptionColumns
+    }
+    val tableDefForSelection = tableDef.copy(regularColumns = tableDef.regularColumns ++ selectableOptionColumns)
+
+    val baseSelectedColumns = columnNames
       .selectFrom(tableDefForSelection)
       .filter(col => !InternalColumns.contains(col.columnName))
-    val rowWriter = implicitly[RowWriterFactory[T]].rowWriter(tablDefWithMeta, selectedColumns)
+    val selectedOnlyPrimaryKeyColumns = baseSelectedColumns.nonEmpty && baseSelectedColumns.forall { col =>
+      tableDef.columnByName.get(col.columnName).exists(_.isPrimaryKeyColumn)
+    }
+    val autoSelectedOptionColumns = writeConf.ttl match {
+      case TTLOption(PerRowWriteOptionValue(placeholder))
+          if !isDelete && selectedOnlyPrimaryKeyColumns && syntheticColumnNames.contains(placeholder) =>
+        candidateAutoSelectedOptionColumns.filterNot(_.columnName == placeholder)
+      case _ => candidateAutoSelectedOptionColumns
+    }
+    // Ensure per-row option placeholder columns (e.g. per-row timestamp/TTL) are included
+    // when the selected column set did not include them.
+    val selectedColumnNames = baseSelectedColumns.map(_.columnName).toSet
+    val missingOptionColumns = autoSelectedOptionColumns.filterNot(c => selectedColumnNames.contains(c.columnName))
+    val selectedColumns = baseSelectedColumns ++ missingOptionColumns.map(c => ColumnName(c.columnName))
 
-    checkColumns(tablDefWithMeta, selectedColumns, checkPartitionKey)
-    new TableWriter[T](connector, tablDefWithMeta, selectedColumns, rowWriter, writeConf, partitions, tokenRangeAcc)
+    val autoAddedOptionColumnNames = missingOptionColumns.map(_.columnName).toSet
+    val deleteOptionColumnNames =
+      if (isDelete) nonPrimaryKeyOptionPlaceholders(tableDef, writeConf) else Set.empty[String]
+    val bindOnlyColumnNames = syntheticColumnNames ++ autoAddedOptionColumnNames ++ deleteOptionColumnNames
+    val selectedColumnsForValidation = selectedColumns.filterNot(c => bindOnlyColumnNames.contains(c.columnName))
+    checkColumns(tableDef, selectedColumnsForValidation, partitionKeyOnly, isDelete)
+
+    val retryWithoutIgnoredDeleteTtl = (writeConf.ttl, writeConf.timestamp) match {
+      case (TTLOption(PerRowWriteOptionValue(ttlPlaceholder)), TimestampOption(PerRowWriteOptionValue(_)))
+          if isDelete && autoAddedOptionColumnNames.contains(ttlPlaceholder) =>
+        Some(ttlPlaceholder)
+      case _ => None
+    }
+
+    val (finalSelectedColumns, finalAutoAddedOptionColumnNames, rowWriter) = rowWriterSelection(
+      implicitly[RowWriterFactory[T]], tablDefWithMeta, optionColumns, selectedColumns, syntheticColumnNames,
+      autoAddedOptionColumnNames, deleteOptionColumnNames, retryWithoutIgnoredDeleteTtl)
+
+    new TableWriter[T](connector, tablDefWithMeta, finalSelectedColumns, rowWriter, writeConf, partitions, tokenRangeAcc, isDelete,
+      syntheticColumnNames = syntheticColumnNames,
+      autoAddedOptionColumnNames = finalAutoAddedOptionColumnNames)
   }
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -56,11 +56,14 @@ case class WriteConf(
   taskMetricsEnabled: Boolean = WriteConf.TaskMetricsParam.default,
   executeAs: Option[String] = None) {
 
-  private[writer] val optionPlaceholders: Seq[String] = Seq(ttl, timestamp).collect {
+  private[connector] val optionPlaceholders: Seq[String] = Seq(ttl, timestamp).collect {
     case WriteOption(PerRowWriteOptionValue(placeholder)) => placeholder
   }
 
-  private[writer] val optionsAsColumns: (String, String) => Seq[ColumnDef] = { (keyspace, table) =>
+  require(optionPlaceholders.distinct.size == optionPlaceholders.size,
+    s"TTL and timestamp per-row placeholders must have different names, got: ${optionPlaceholders.mkString(", ")}")
+
+  private[connector] val optionsAsColumns: (String, String) => Seq[ColumnDef] = { (_, _) =>
     def toRegularColDef(opt: WriteOption[_], dataType: DataType) = opt match {
       case WriteOption(PerRowWriteOptionValue(placeholder)) =>
         Some(ColumnDef(placeholder, RegularColumn, ColumnType.fromDriverType(dataType)))
@@ -68,6 +71,27 @@ case class WriteConf(
     }
 
     Seq(toRegularColDef(ttl, DataTypes.INT), toRegularColDef(timestamp, DataTypes.BIGINT)).flatten
+  }
+
+  /** Returns a copy suitable for DELETE operations.
+    * Strips ifNotExists (INSERT-only), ignoreNulls (DELETE only binds
+    * primary key columns which are always non-null, making the flag
+    * meaningless), and static TTL (CQL DELETE does not support TTL;
+    * keeping a static value would be misleading since the DELETE template
+    * never emits it). Per-row TTL is kept so that the option-placeholder
+    * column remains in the table definition for positional alignment with
+    * tuple-based RDDs. The DELETE query template simply omits TTL from the
+    * generated CQL. */
+  private[connector] def forDelete: WriteConf = {
+    val deleteTtl = ttl match {
+      case TTLOption(StaticWriteOptionValue(_)) => TTLOption.defaultValue
+      case other => other
+    }
+    copy(
+      ifNotExists = false,
+      ignoreNulls = false,
+      ttl = deleteTtl
+    )
   }
 
   val throttlingEnabled = throughputMiBPS.isDefined

--- a/connector/src/test/scala/com/datastax/spark/connector/writer/TableWriterRegressionTest.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/writer/TableWriterRegressionTest.scala
@@ -1,0 +1,523 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.spark.connector.writer
+
+import java.io.{ByteArrayOutputStream, ObjectOutputStream}
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import java.util.{Collections => JCollections}
+
+import com.datastax.oss.driver.api.core.{CqlIdentifier, CqlSession, ProtocolVersion}
+import com.datastax.oss.driver.api.core.`type`.codec.registry.CodecRegistry
+import com.datastax.oss.driver.api.core.context.DriverContext
+import com.datastax.oss.driver.api.core.cql.{BoundStatement, ColumnDefinition, ColumnDefinitions, PreparedStatement, SimpleStatement}
+import com.datastax.oss.driver.internal.core.cql.{DefaultColumnDefinition, DefaultColumnDefinitions, DefaultPreparedStatement}
+import com.datastax.oss.protocol.internal.ProtocolConstants
+import com.datastax.oss.protocol.internal.response.result.{ColumnSpec, RawType}
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql._
+import com.datastax.spark.connector.types.{CounterType, IntType, ListType, SetType, TextType, UUIDType}
+import org.apache.spark.TaskContext
+import org.junit.{Assert, Test}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
+
+import scala.jdk.CollectionConverters._
+
+class TableWriterRegressionTest {
+
+  case class RowWithTtlPlaceholder(pk: Int, ck: Int, value: String, ttl_col: Int)
+  case class DeleteKeyWithTimestampOnly(pk: Int, ck: Int, write_ts: Long)
+
+  private def createConnector(): CassandraConnector = {
+    val contactInfo = IpBasedContactInfo(Set(new InetSocketAddress("127.0.0.1", 9042)))
+    val connectorConf = CassandraConnectorConf(contactInfo)
+    new CassandraConnector(connectorConf)
+  }
+
+  private def createTableDef(regularColumns: Seq[ColumnDef] = Seq.empty): TableDef = {
+    val pk = ColumnDef("pk", PartitionKeyColumn, IntType)
+    val ck = ColumnDef("ck", ClusteringColumn(0), IntType)
+    val columns = if (regularColumns.nonEmpty) regularColumns else Seq(ColumnDef("value", RegularColumn, TextType))
+    TableDef("test_ks", "test_table", Seq(pk), Seq(ck), columns)
+  }
+
+  private def assertSerializable(value: AnyRef): Unit = {
+    val baos = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject(value)
+    oos.close()
+  }
+
+  private def columnDefinitions(columns: (String, Int)*): ColumnDefinitions = {
+    DefaultColumnDefinitions.valueOf(columns.zipWithIndex.map { case ((name, dataType), index) =>
+      val columnSpec = new ColumnSpec("ks", "tab", name, index, RawType.PRIMITIVES.get(dataType))
+      new DefaultColumnDefinition(columnSpec, null).asInstanceOf[ColumnDefinition]
+    }.toList.asJava)
+  }
+
+  private def preparedStatementWithVariables(columns: (String, Int)*): PreparedStatement = {
+    new DefaultPreparedStatement(
+      ByteBuffer.wrap(Array[Byte](1)),
+      "test query",
+      columnDefinitions(columns: _*),
+      JCollections.emptyList[java.lang.Integer](),
+      null,
+      columnDefinitions(),
+      CqlIdentifier.fromInternal("ks"),
+      null,
+      JCollections.emptyMap[String, ByteBuffer](),
+      null,
+      null,
+      CqlIdentifier.fromInternal("tab"),
+      null,
+      null,
+      JCollections.emptyMap[String, ByteBuffer](),
+      java.lang.Boolean.TRUE,
+      null,
+      null,
+      0,
+      null,
+      null,
+      false,
+      CodecRegistry.DEFAULT,
+      ProtocolVersion.DEFAULT,
+      false)
+  }
+
+  private def connectorReturning(preparedStatement: PreparedStatement): CassandraConnector = {
+    val session = mock(classOf[CqlSession])
+    val context = mock(classOf[DriverContext])
+    when(context.getProtocolVersion).thenReturn(ProtocolVersion.DEFAULT)
+    when(session.getContext).thenReturn(context)
+    when(session.prepare(any(classOf[SimpleStatement]))).thenReturn(preparedStatement)
+
+    new CassandraConnector(createConnector().conf) {
+      override def openSession(): CqlSession = session
+      override def withSessionDo[T](code: CqlSession => T): T = code(session)
+    }
+  }
+
+  private def asyncWriterForQuery[T](
+      writer: TableWriter[T],
+      query: String,
+      isDeleteStatement: Boolean): AsyncStatementWriter[T] = {
+    val method = writer.getClass.getDeclaredMethods.find { method =>
+      method.getName.contains("getAsyncWriterInternal") && method.getParameterTypes.length == 3
+    }.get
+    method.setAccessible(true)
+    method.invoke(
+      writer,
+      query,
+      None,
+      java.lang.Boolean.valueOf(isDeleteStatement)).asInstanceOf[AsyncStatementWriter[T]]
+  }
+
+  private def asyncWriterForDeleteCompatibilityPath(
+      writer: TableWriter[Seq[Any]]): AsyncStatementWriter[Seq[Any]] = {
+    asyncWriterForQuery(
+      writer,
+      "DELETE FROM test_ks.test_table WHERE \"pk\" = :\"pk\"",
+      isDeleteStatement = true)
+  }
+
+  @Test
+  def legacyDeleteWithPerRowTtlShouldNotRequirePlaceholderWhenKeyColumnsOmitIt(): Unit = {
+    val writer = TableWriter[(Int, Int)](
+      createConnector(), createTableDef(), PrimaryKeyColumns, WriteConf(ttl = TTLOption.perRow("ignored_ttl")),
+      checkPartitionKey = true, partitions = Array.empty, tokenRangeAcc = None)
+
+    Assert.assertEquals(Vector("pk", "ck"), writer.columnNames)
+    assertSerializable((writer.delete(SomeColumns()) _).asInstanceOf[(TaskContext, Iterator[(Int, Int)]) => Unit])
+  }
+
+  @Test
+  def deleteWithPerRowTtlAndTimestampShouldNotRequireIgnoredTtlProperty(): Unit = {
+    val deleteConf = WriteConf(
+      ttl = TTLOption.perRow("ignored_ttl"),
+      timestamp = TimestampOption.perRow("write_ts")).forDelete
+
+    val writer = TableWriter[DeleteKeyWithTimestampOnly](
+      createConnector(), createTableDef(), PrimaryKeyColumns, deleteConf, partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+
+    Assert.assertEquals(Vector("pk", "ck"), writer.columnNames)
+    Assert.assertTrue(writer.deleteQueryTemplate(SomeColumns()).contains("USING TIMESTAMP :write_ts"))
+  }
+
+  @Test
+  def insertQueryShouldRejectUnboundSyntheticPerRowTtlPlaceholder(): Unit = {
+    val writer = TableWriter[(Int, Int)](
+      createConnector(), createTableDef(), PrimaryKeyColumns, WriteConf(ttl = TTLOption.perRow("ttl_col")),
+      checkPartitionKey = false, partitions = Array.empty, tokenRangeAcc = None)
+
+    try {
+      writer.queryTemplateUsingInsert
+      Assert.fail("Expected INSERT generation to reject an unbound per-row TTL placeholder")
+    } catch {
+      case e: IllegalArgumentException =>
+        Assert.assertTrue(e.getMessage.contains("INSERT"))
+        Assert.assertTrue(e.getMessage.contains("ttl_col"))
+    }
+  }
+
+  @Test
+  def boundStatementBuilderShouldBindDuplicateMarkersAndCountEveryOccurrence(): Unit = {
+    val preparedStatement = preparedStatementWithVariables(
+      "id" -> ProtocolConstants.DataType.INT,
+      "ttl_col" -> ProtocolConstants.DataType.INT,
+      "value" -> ProtocolConstants.DataType.VARCHAR,
+      "ttl_col" -> ProtocolConstants.DataType.INT)
+    val rowWriter = new RowWriter[Seq[Any]] {
+      override def columnNames: Seq[String] = Seq("id", "ttl_col", "value")
+      override def readColumnValues(data: Seq[Any], buffer: Array[Any]): Unit =
+        data.zipWithIndex.foreach { case (value, index) => buffer(index) = value }
+    }
+
+    val builder = new BoundStatementBuilder(rowWriter, preparedStatement, protocolVersion = ProtocolVersion.DEFAULT)
+    val bound = builder.bind(Seq(1, 60, "abc"))
+    val ttlMarkerIndices = preparedStatement.getVariableDefinitions.allIndicesOf("ttl_col").asScala
+
+    Assert.assertEquals(2, ttlMarkerIndices.size)
+    ttlMarkerIndices.foreach { index =>
+      Assert.assertNotNull(bound.stmt.getBytesUnsafe(index))
+    }
+    Assert.assertEquals(BoundStatementBuilder.calculateDataSize(bound.stmt), bound.bytesCount)
+  }
+
+  @Test
+  def boundStatementBuilderShouldNotOverwritePrefixValuesWithDuplicateMarkerNames(): Unit = {
+    val preparedStatement = preparedStatementWithVariables(
+      "key" -> ProtocolConstants.DataType.INT,
+      "key" -> ProtocolConstants.DataType.INT)
+    val rowWriter = new RowWriter[Seq[Any]] {
+      override def columnNames: Seq[String] = Seq("key")
+      override def readColumnValues(data: Seq[Any], buffer: Array[Any]): Unit = buffer(0) = data.head
+    }
+
+    val builder = new BoundStatementBuilder(
+      rowWriter,
+      preparedStatement,
+      prefixVals = Seq(99),
+      protocolVersion = ProtocolVersion.DEFAULT)
+    val bound = builder.bind(Seq(7)).stmt
+
+    Assert.assertEquals("The prefix marker must keep the value supplied through prefixVals", 99, bound.getInt(0))
+    Assert.assertEquals("The row marker should use the value read from the row", 7, bound.getInt(1))
+  }
+
+  @Test
+  def boundStatementBuilderShouldKeepQuotedMarkerCaseDistinct(): Unit = {
+    val preparedStatement = preparedStatementWithVariables(
+      "Foo" -> ProtocolConstants.DataType.INT,
+      "foo" -> ProtocolConstants.DataType.INT)
+    val rowWriter = new RowWriter[Seq[Any]] {
+      override def columnNames: Seq[String] = Seq("Foo", "foo")
+      override def readColumnValues(data: Seq[Any], buffer: Array[Any]): Unit =
+        data.zipWithIndex.foreach { case (value, index) => buffer(index) = value }
+    }
+
+    val bound = new BoundStatementBuilder(
+      rowWriter,
+      preparedStatement,
+      protocolVersion = ProtocolVersion.DEFAULT)
+      .bind(Seq(1, 2))
+      .stmt
+
+    Assert.assertEquals(1, bound.getInt(0))
+    Assert.assertEquals(2, bound.getInt(1))
+  }
+
+  @Test
+  def autoTimestampBindingShouldKeepQuotedMarkerCaseDistinct(): Unit = {
+    val preparedStatement = preparedStatementWithVariables(
+      "Connector_autots" -> ProtocolConstants.DataType.VARCHAR,
+      TableWriter.AutoTimestampParam -> ProtocolConstants.DataType.BIGINT)
+    val rowWriter = new RowWriter[Seq[Any]] {
+      override def columnNames: Seq[String] = Seq("Connector_autots")
+      override def readColumnValues(data: Seq[Any], buffer: Array[Any]): Unit = buffer(0) = data.head
+    }
+
+    val bound = new BoundStatementBuilder(
+      rowWriter,
+      preparedStatement,
+      protocolVersion = ProtocolVersion.DEFAULT,
+      autoTimestampParam = Some(TableWriter.AutoTimestampParam))
+      .bind(Seq("user-value"))
+      .stmt
+
+    Assert.assertEquals("user-value", bound.getString(0))
+    Assert.assertTrue(bound.getLong(1) > 0L)
+  }
+
+  @Test
+  def counterTableUpdateQueryShouldNotContainUsingTTL(): Unit = {
+    val connector = createConnector()
+    val counter = ColumnDef("c", RegularColumn, CounterType)
+    val pk = ColumnDef("pk", PartitionKeyColumn, IntType)
+    val tableDef = TableDef("test_ks", "test_counters", Seq(pk), Seq.empty, Seq(counter))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, AllColumns, WriteConf(ttl = TTLOption.constant(100)),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.queryTemplateUsingUpdate
+    Assert.assertFalse("Counter UPDATE should not contain USING TTL", query.contains("USING TTL"))
+    Assert.assertFalse("Counter UPDATE should not contain USING TIMESTAMP", query.contains("USING TIMESTAMP"))
+  }
+
+  @Test
+  def insertQueryShouldQuotePerRowOptionPlaceholders(): Unit = {
+    val connector = createConnector()
+    val regular = ColumnDef("value", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(regular))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, AllColumns,
+      WriteConf(ttl = TTLOption.perRow("ttl-column"), timestamp = TimestampOption.perRow("write-ts")),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.queryTemplateUsingInsert
+    Assert.assertTrue("INSERT should quote the TTL bind marker", query.contains("TTL :\"ttl-column\""))
+    Assert.assertTrue("INSERT should quote the TIMESTAMP bind marker", query.contains("TIMESTAMP :\"write-ts\""))
+  }
+
+  @Test
+  def updateQueryShouldQuotePerRowOptionPlaceholders(): Unit = {
+    val connector = createConnector()
+    val setColumn = ColumnDef("scol", RegularColumn, SetType(TextType))
+    val tableDef = createTableDef(regularColumns = Seq(setColumn))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, SomeColumns("pk", "ck", "scol".append),
+      WriteConf(ttl = TTLOption.perRow("ttl-column"), timestamp = TimestampOption.perRow("write-ts")),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.queryTemplateUsingUpdate
+    Assert.assertTrue("UPDATE should quote the TTL bind marker", query.contains("TTL :\"ttl-column\""))
+    Assert.assertTrue("UPDATE should quote the TIMESTAMP bind marker", query.contains("TIMESTAMP :\"write-ts\""))
+  }
+
+  @Test
+  def deleteQueryShouldQuotePerRowOptionPlaceholders(): Unit = {
+    val connector = createConnector()
+    val tableDef = createTableDef()
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, WriteConf(timestamp = TimestampOption.perRow("write-ts")),
+      partitionKeyOnly = true, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.deleteQueryTemplate(SomeColumns())
+    Assert.assertTrue("DELETE should quote the TIMESTAMP bind marker", query.contains("TIMESTAMP :\"write-ts\""))
+  }
+
+  @Test
+  def perRowOptionPlaceholdersShouldQuoteReservedKeywords(): Unit = {
+    val connector = createConnector()
+    val setColumn = ColumnDef("scol", RegularColumn, SetType(TextType))
+    val tableDef = createTableDef(regularColumns = Seq(setColumn))
+
+    val insertWriter = TableWriter[CassandraRow](
+      connector, tableDef, AllColumns, WriteConf(ttl = TTLOption.perRow("select")),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+    Assert.assertTrue("INSERT should quote reserved TTL bind marker",
+      insertWriter.queryTemplateUsingInsert.contains("TTL :\"select\""))
+
+    val updateWriter = TableWriter[CassandraRow](
+      connector, tableDef, SomeColumns("pk", "ck", "scol".append),
+      WriteConf(timestamp = TimestampOption.perRow("select")),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+    Assert.assertTrue("UPDATE should quote reserved TIMESTAMP bind marker",
+      updateWriter.queryTemplateUsingUpdate.contains("TIMESTAMP :\"select\""))
+
+    val deleteWriter = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, WriteConf(timestamp = TimestampOption.perRow("select")),
+      partitionKeyOnly = true, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+    Assert.assertTrue("DELETE should quote reserved TIMESTAMP bind marker",
+      deleteWriter.deleteQueryTemplate(SomeColumns()).contains("TIMESTAMP :\"select\""))
+  }
+
+  @Test
+  def legacyDeleteCompatibilityPathShouldMarkEmittedStatementsIdempotent(): Unit = {
+    val listColumn = ColumnDef("lcol", RegularColumn, ListType(TextType))
+    val tableDef = createTableDef(regularColumns = Seq(listColumn))
+    implicit val rowWriterFactory: RowWriterFactory[Seq[Any]] = new RowWriterFactory[Seq[Any]] {
+      override def rowWriter(table: TableDef, selectedColumns: IndexedSeq[ColumnRef]): RowWriter[Seq[Any]] = {
+        new RowWriter[Seq[Any]] {
+          override def columnNames: Seq[String] = selectedColumns.map(_.columnName)
+          override def readColumnValues(data: Seq[Any], buffer: Array[Any]): Unit =
+            data.zipWithIndex.foreach { case (value, index) => buffer(index) = value }
+        }
+      }
+    }
+    val connector = connectorReturning(preparedStatementWithVariables("pk" -> ProtocolConstants.DataType.INT))
+    val writer = TableWriter[Seq[Any]](
+      connector, tableDef, SomeColumns("pk", "lcol".append), WriteConf(batchGroupingKey = BatchGroupingKey.None),
+      checkPartitionKey = true, partitions = Array.empty, tokenRangeAcc = None)
+
+    Assert.assertFalse("The original collection-append writer is non-idempotent", writer.isIdempotent)
+
+    val asyncWriter = asyncWriterForDeleteCompatibilityPath(writer)
+    asyncWriter.groupingBatchBuilderBase.batchRecord(Seq(1, Seq("value")))
+    val deleteStatement = asyncWriter.groupingBatchBuilderBase.finish().head.stmt
+
+    Assert.assertEquals("DELETE statements are idempotent even when the source writer is not",
+      java.lang.Boolean.TRUE, deleteStatement.isIdempotent)
+  }
+
+  @Test
+  def autoSelectedTtlPlaceholderShouldBindWithOptionTypeWhenNameMatchesUnselectedRealColumn(): Unit = {
+    val ttlCol = ColumnDef("ttl_col", RegularColumn, UUIDType)
+    val value = ColumnDef("value", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(ttlCol, value))
+    val preparedStatement = preparedStatementWithVariables(
+      "pk" -> ProtocolConstants.DataType.INT,
+      "ck" -> ProtocolConstants.DataType.INT,
+      "value" -> ProtocolConstants.DataType.VARCHAR,
+      "ttl_col" -> ProtocolConstants.DataType.INT)
+    val connector = connectorReturning(preparedStatement)
+
+    val writer = TableWriter[RowWithTtlPlaceholder](
+      connector, tableDef, SomeColumns("pk", "ck", "value"),
+      WriteConf(batchGroupingKey = BatchGroupingKey.None, ttl = TTLOption.perRow("ttl_col")),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val asyncWriter = writer.getAsyncWriter()
+    asyncWriter.groupingBatchBuilderBase.batchRecord(RowWithTtlPlaceholder(1, 2, "abc", 60))
+    val bound = asyncWriter.groupingBatchBuilderBase.finish().head.stmt.asInstanceOf[BoundStatement]
+
+    Assert.assertEquals(60, bound.getInt(3))
+  }
+
+  @Test
+  def explicitDeleteTtlPlaceholderShouldUseOptionTypeWhenNameMatchesRealColumn(): Unit = {
+    val ttlCol = ColumnDef("ttl_col", RegularColumn, UUIDType)
+    val value = ColumnDef("value", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(ttlCol, value))
+    val preparedStatement = preparedStatementWithVariables(
+      "pk" -> ProtocolConstants.DataType.INT,
+      "ck" -> ProtocolConstants.DataType.INT)
+    val connector = connectorReturning(preparedStatement)
+
+    val writer = TableWriter[(Int, Int, Int)](
+      connector, tableDef, SomeColumns("pk", "ck", "ttl_col"),
+      WriteConf(batchGroupingKey = BatchGroupingKey.None, ttl = TTLOption.perRow("ttl_col")).forDelete,
+      partitionKeyOnly = true, partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+
+    val asyncWriter = asyncWriterForQuery(
+      writer,
+      writer.deleteQueryTemplate(SomeColumns()),
+      isDeleteStatement = true)
+    asyncWriter.groupingBatchBuilderBase.batchRecord((1, 2, 60))
+    val bound = asyncWriter.groupingBatchBuilderBase.finish().head.stmt.asInstanceOf[BoundStatement]
+
+    Assert.assertEquals(1, bound.getInt(0))
+    Assert.assertEquals(2, bound.getInt(1))
+  }
+
+  @Test
+  def explicitDeleteTimestampPlaceholderShouldUseOptionTypeWhenNameMatchesRealColumn(): Unit = {
+    val tsCol = ColumnDef("write_ts", RegularColumn, UUIDType)
+    val value = ColumnDef("value", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(tsCol, value))
+    val preparedStatement = preparedStatementWithVariables(
+      "write_ts" -> ProtocolConstants.DataType.BIGINT,
+      "pk" -> ProtocolConstants.DataType.INT,
+      "ck" -> ProtocolConstants.DataType.INT)
+    val connector = connectorReturning(preparedStatement)
+    val writeTs = 1400000000000L
+
+    val writer = TableWriter[(Int, Int, Long)](
+      connector, tableDef, SomeColumns("pk", "ck", "write_ts"),
+      WriteConf(batchGroupingKey = BatchGroupingKey.None, timestamp = TimestampOption.perRow("write_ts")).forDelete,
+      partitionKeyOnly = true, partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+
+    val asyncWriter = asyncWriterForQuery(
+      writer,
+      writer.deleteQueryTemplate(SomeColumns()),
+      isDeleteStatement = true)
+    asyncWriter.groupingBatchBuilderBase.batchRecord((1, 2, writeTs))
+    val bound = asyncWriter.groupingBatchBuilderBase.finish().head.stmt.asInstanceOf[BoundStatement]
+
+    Assert.assertEquals(writeTs, bound.getLong(0))
+    Assert.assertEquals(1, bound.getInt(1))
+    Assert.assertEquals(2, bound.getInt(2))
+  }
+
+  @Test
+  def deleteWithPerRowTtlAndTimestampShouldPreserveTuplePositionWhenKeyColumnsOmitTtl(): Unit = {
+    val tableDef = createTableDef()
+    val preparedStatement = preparedStatementWithVariables(
+      "write_ts" -> ProtocolConstants.DataType.BIGINT,
+      "pk" -> ProtocolConstants.DataType.INT,
+      "ck" -> ProtocolConstants.DataType.INT)
+    val connector = connectorReturning(preparedStatement)
+    val writeTs = 1400000000000L
+
+    val writer = TableWriter[(Int, Int, Int, Long)](
+      connector, tableDef, PrimaryKeyColumns,
+      WriteConf(
+        batchGroupingKey = BatchGroupingKey.None,
+        ttl = TTLOption.perRow("ignored_ttl"),
+        timestamp = TimestampOption.perRow("write_ts")).forDelete,
+      partitionKeyOnly = true, partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+
+    val asyncWriter = asyncWriterForQuery(
+      writer,
+      writer.deleteQueryTemplate(SomeColumns()),
+      isDeleteStatement = true)
+    asyncWriter.groupingBatchBuilderBase.batchRecord((1, 2, 99999, writeTs))
+    val bound = asyncWriter.groupingBatchBuilderBase.finish().head.stmt.asInstanceOf[BoundStatement]
+
+    Assert.assertEquals(writeTs, bound.getLong(0))
+    Assert.assertEquals(1, bound.getInt(1))
+    Assert.assertEquals(2, bound.getInt(2))
+  }
+
+  @Test
+  def deleteWithPerRowTtlAndTimestampShouldNotReadIgnoredTtlFromCassandraRow(): Unit = {
+    val tableDef = createTableDef()
+    val preparedStatement = preparedStatementWithVariables(
+      "write_ts" -> ProtocolConstants.DataType.BIGINT,
+      "pk" -> ProtocolConstants.DataType.INT,
+      "ck" -> ProtocolConstants.DataType.INT)
+    val connector = connectorReturning(preparedStatement)
+    val writeTs = 1400000000000L
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns,
+      WriteConf(
+        batchGroupingKey = BatchGroupingKey.None,
+        ttl = TTLOption.perRow("ignored_ttl"),
+        timestamp = TimestampOption.perRow("write_ts")).forDelete,
+      partitionKeyOnly = true, partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+
+    val asyncWriter = asyncWriterForQuery(
+      writer,
+      writer.deleteQueryTemplate(SomeColumns()),
+      isDeleteStatement = true)
+    asyncWriter.groupingBatchBuilderBase.batchRecord(
+      CassandraRow.fromMap(Map("pk" -> 1, "ck" -> 2, "write_ts" -> writeTs)))
+    val bound = asyncWriter.groupingBatchBuilderBase.finish().head.stmt.asInstanceOf[BoundStatement]
+
+    Assert.assertEquals(writeTs, bound.getLong(0))
+    Assert.assertEquals(1, bound.getInt(1))
+    Assert.assertEquals(2, bound.getInt(2))
+  }
+}

--- a/connector/src/test/scala/com/datastax/spark/connector/writer/TableWriterTest.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/writer/TableWriterTest.scala
@@ -1,0 +1,784 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.spark.connector.writer
+
+import java.io.{ByteArrayOutputStream, ObjectOutputStream}
+import java.net.InetSocketAddress
+
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql._
+import com.datastax.spark.connector.types.{BigIntType, CounterType, IntType, SetType, TextType}
+import org.junit.{Assert, Test}
+import org.apache.spark.{Partition, TaskContext}
+
+class TableWriterTest {
+
+  private def createConnector(): CassandraConnector = {
+    val contactInfo = IpBasedContactInfo(Set(new InetSocketAddress("127.0.0.1", 9042)))
+    val connectorConf = CassandraConnectorConf(contactInfo)
+    new CassandraConnector(connectorConf)
+  }
+
+  private def createTableDef(regularColumns: Seq[ColumnDef] = Seq.empty): TableDef = {
+    val pk = ColumnDef("pk", PartitionKeyColumn, IntType)
+    val ck = ColumnDef("ck", ClusteringColumn(0), IntType)
+    TableDef("test_ks", "test_table", Seq(pk), Seq(ck), regularColumns)
+  }
+
+  private def assertSerializable(value: AnyRef): Unit = {
+    val baos = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject(value)
+    oos.close()
+  }
+
+  private class RecordingRowWriterFactory extends RowWriterFactory[CassandraRow] {
+    var selectedColumns: IndexedSeq[ColumnRef] = IndexedSeq.empty
+
+    override def rowWriter(table: TableDef, selectedColumns: IndexedSeq[ColumnRef]): RowWriter[CassandraRow] = {
+      this.selectedColumns = selectedColumns
+      new RowWriter[CassandraRow] {
+        override def columnNames: Seq[String] = selectedColumns.map(_.columnName)
+        override def readColumnValues(data: CassandraRow, buffer: Array[Any]): Unit = ()
+      }
+    }
+  }
+
+  @Test
+  def autoTimestampCounterShouldNotStartFarInTheFuture(): Unit = {
+    val before = System.currentTimeMillis() * 1000
+    val seed = BoundStatementBuilder.globalAutoTsCounter.get()
+    val after = System.currentTimeMillis() * 1000
+
+    Assert.assertTrue(
+      s"Auto timestamp seed $seed should not be more than 100ms ahead of wall clock [$before, $after]",
+      seed <= after + 100000L)
+  }
+
+  @Test
+  def deleteClosureShouldBeSerializable(): Unit = {
+    val connector = createConnector()
+    val tableDef = createTableDef()
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, WriteConf(), partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+
+    val deleteFunc: (TaskContext, Iterator[CassandraRow]) => Unit = writer.deleteRows _
+
+    assertSerializable(deleteFunc) // must not throw NotSerializableException
+  }
+
+  @Test
+  def deleteClosureWithPerRowTimestampShouldBeSerializable(): Unit = {
+    val connector = createConnector()
+    val tableDef = createTableDef()
+    val writeConf = WriteConf(timestamp = TimestampOption.perRow("_ts"))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, writeConf, partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+
+    val deleteFunc: (TaskContext, Iterator[CassandraRow]) => Unit = writer.deleteRows _
+
+    assertSerializable(deleteFunc) // must not throw NotSerializableException
+  }
+
+  @Test
+  def deleteWithColumnSelectorShouldRemainSourceCompatible(): Unit = {
+    val connector = createConnector()
+    val tableDef = createTableDef()
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, WriteConf(), checkPartitionKey = true,
+      partitions = Array.empty, tokenRangeAcc = None)
+
+    val deleteFunc: (TaskContext, Iterator[CassandraRow]) => Unit = writer.delete(SomeColumns()) _
+
+    assertSerializable(deleteFunc)
+  }
+
+  @Test
+  def deleteMethodValueShouldRemainSourceCompatible(): Unit = {
+    val connector = createConnector()
+    val tableDef = createTableDef()
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, WriteConf(), checkPartitionKey = true,
+      partitions = Array.empty, tokenRangeAcc = None)
+
+    val deleteFunc = writer.delete _
+
+    assertSerializable(deleteFunc)
+  }
+
+  @Test
+  def deleteWithPerRowTtlShouldSucceedWhenKeyColumnsOmitPlaceholder(): Unit = {
+    val connector = createConnector()
+    val tableDef = createTableDef()
+    val writeConf = WriteConf(ttl = TTLOption.perRow("ignored_ttl"))
+    val deleteConf = writeConf.forDelete
+
+    // forDelete keeps per-row TTL for positional alignment; the DELETE template omits it
+    Assert.assertTrue(
+      "forDelete should keep per-row TTL placeholder",
+      deleteConf.optionPlaceholders.contains("ignored_ttl"))
+
+    // Building a TableWriter with PrimaryKeyColumns and the delete conf should succeed
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, deleteConf, partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+
+    val deleteFunc: (TaskContext, Iterator[CassandraRow]) => Unit = writer.deleteRows _
+
+    assertSerializable(deleteFunc)
+  }
+
+  @Test
+  def deleteWithPerRowTtlShouldNotRequirePlaceholderWhenKeyColumnsOmitIt(): Unit = {
+    val connector = createConnector()
+    val tableDef = createTableDef()
+    val deleteConf = WriteConf(ttl = TTLOption.perRow("ignored_ttl")).forDelete
+
+    val writer = TableWriter[(Int, Int)](
+      connector, tableDef, PrimaryKeyColumns, deleteConf, partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+
+    Assert.assertEquals(Vector("pk", "ck"), writer.columnNames)
+  }
+
+  @Test
+  def deleteWithPerRowTtlShouldKeepExplicitPlaceholderForTupleAlignment(): Unit = {
+    val connector = createConnector()
+    val tableDef = createTableDef()
+    val deleteConf = WriteConf(ttl = TTLOption.perRow("ignored_ttl")).forDelete
+
+    val writer = TableWriter[(Int, Int, Int)](
+      connector, tableDef, SomeColumns("pk", "ck", "ignored_ttl"), deleteConf,
+      partitionKeyOnly = true, partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+
+    Assert.assertEquals(Vector("pk", "ck"), writer.columnNames)
+  }
+
+  @Test
+  def deleteQueryTemplateShouldRejectRegularColumnsAsKeyColumns(): Unit = {
+    val connector = createConnector()
+    val regular = ColumnDef("value", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(regular))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, AllColumns, WriteConf(), partitionKeyOnly = false,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    try {
+      writer.deleteQueryTemplate(SomeColumns())
+      Assert.fail("Expected IllegalArgumentException for regular columns as key columns")
+    } catch {
+      case e: IllegalArgumentException =>
+        Assert.assertTrue(e.getMessage.contains("Regular columns found"))
+    }
+  }
+
+  @Test
+  def deleteQueryTemplateWithAllColumnsShouldAutoFilterPrimaryKeyColumns(): Unit = {
+    val connector = createConnector()
+    val regular = ColumnDef("value", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(regular))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, WriteConf(), partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.deleteQueryTemplate(AllColumns)
+    Assert.assertTrue("Should contain the regular column", query.contains("\"value\""))
+    Assert.assertFalse("Should not contain pk column in delete spec", query.contains("\"pk\" FROM"))
+    Assert.assertFalse("Should not contain ck column in delete spec", query.contains("\"ck\" FROM"))
+  }
+
+  @Test
+  def deleteQueryTemplateWithAllColumnsOnPkOnlyTableShouldProduceFullRowDelete(): Unit = {
+    val connector = createConnector()
+    // Table with only primary key columns (no regular columns)
+    val tableDef = createTableDef(regularColumns = Seq.empty)
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, WriteConf(), partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.deleteQueryTemplate(AllColumns)
+    // Should be a full-row DELETE (no column list before FROM)
+    Assert.assertTrue("Should be a full-row DELETE", query.startsWith("DELETE FROM"))
+    Assert.assertTrue("Should contain WHERE clause", query.contains("WHERE"))
+  }
+
+  @Test
+  def allColumnsDeleteOnPkOnlyTableShouldNotRequireFullPrimaryKey(): Unit = {
+    val tableDef = createTableDef(regularColumns = Seq.empty)
+
+    Assert.assertFalse(TableWriter.isColumnDelete(tableDef, AllColumns))
+  }
+
+  @Test
+  def allColumnsDeleteOnTableWithRegularColumnsShouldRequireFullPrimaryKey(): Unit = {
+    val regular = ColumnDef("value", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(regular))
+
+    Assert.assertTrue(TableWriter.isColumnDelete(tableDef, AllColumns))
+  }
+
+  @Test
+  def regularColumnDeleteShouldRejectPartitionKeyOnly(): Unit = {
+    val connector = createConnector()
+    val regular = ColumnDef("value", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(regular))
+    val deleteColumns = SomeColumns("value")
+
+    try {
+      TableWriter[CassandraRow](
+        connector, tableDef, SomeColumns("pk"), WriteConf(),
+        partitionKeyOnly = !TableWriter.isColumnDelete(tableDef, deleteColumns),
+        partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+      Assert.fail("Expected regular column delete to require the full primary key")
+    } catch {
+      case e: IllegalArgumentException =>
+        Assert.assertTrue(e.getMessage.contains("ck"))
+    }
+  }
+
+  @Test
+  def legacyDeleteQueryTemplateShouldRejectNonStaticColumnDeleteWithoutFullPrimaryKey(): Unit = {
+    val connector = createConnector()
+    val regular = ColumnDef("value", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(regular))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, SomeColumns("pk"), WriteConf(), partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    try {
+      writer.deleteQueryTemplate(SomeColumns("value"))
+      Assert.fail("Expected non-static column delete to require the full primary key")
+    } catch {
+      case e: IllegalArgumentException =>
+        Assert.assertTrue(e.getMessage.contains("full primary key"))
+        Assert.assertTrue(e.getMessage.contains("ck"))
+    }
+  }
+
+  @Test
+  def staticColumnDeleteShouldAllowPartitionKeyOnly(): Unit = {
+    val connector = createConnector()
+    val staticCol = ColumnDef("static_value", StaticColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(staticCol))
+    val deleteColumns = SomeColumns("static_value")
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, SomeColumns("pk"), WriteConf(),
+      partitionKeyOnly = !TableWriter.isColumnDelete(tableDef, deleteColumns),
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+
+    val query = writer.deleteQueryTemplate(deleteColumns)
+    Assert.assertTrue("DELETE should include the static column", query.contains("\"static_value\""))
+    Assert.assertTrue("DELETE should use only the partition key", query.contains("WHERE \"pk\" = :\"pk\""))
+    Assert.assertFalse("DELETE should not require the clustering column", query.contains("\"ck\" = :\"ck\""))
+  }
+
+  @Test
+  def staticColumnDeleteWithPrimaryKeyColumnsShouldUseOnlyPartitionKey(): Unit = {
+    val connector = createConnector()
+    val staticCol = ColumnDef("static_value", StaticColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(staticCol))
+    val deleteColumns = SomeColumns("static_value")
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, WriteConf(),
+      partitionKeyOnly = !TableWriter.isColumnDelete(tableDef, deleteColumns),
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+
+    val query = writer.deleteQueryTemplate(deleteColumns)
+    Assert.assertTrue("DELETE should include the static column", query.contains("\"static_value\""))
+    Assert.assertTrue("DELETE should use the partition key", query.contains("WHERE \"pk\" = :\"pk\""))
+    Assert.assertFalse("DELETE should not include the clustering column for a static-only delete",
+      query.contains("\"ck\" = :\"ck\""))
+  }
+
+  @Test
+  def allColumnsDeleteOnStaticOnlyTableShouldAllowPartitionKeyOnly(): Unit = {
+    val connector = createConnector()
+    val staticCol = ColumnDef("static_value", StaticColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(staticCol))
+    val deleteColumns = AllColumns
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, SomeColumns("pk"), WriteConf(),
+      partitionKeyOnly = !TableWriter.isColumnDelete(tableDef, deleteColumns),
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+
+    val query = writer.deleteQueryTemplate(deleteColumns)
+    Assert.assertTrue("DELETE should include the static column", query.contains("\"static_value\""))
+    Assert.assertTrue("DELETE should use only the partition key", query.contains("WHERE \"pk\" = :\"pk\""))
+    Assert.assertFalse("DELETE should not require the clustering column", query.contains("\"ck\" = :\"ck\""))
+  }
+
+  @Test
+  def deleteWithPerRowTimestampAndPrimaryKeyColumnsShouldIncludePlaceholder(): Unit = {
+    val connector = createConnector()
+    val tableDef = createTableDef()
+    val writeConf = WriteConf(timestamp = TimestampOption.perRow("_ts"))
+
+    // PrimaryKeyColumns would not normally select the synthetic "_ts" column.
+    // The fix ensures it is automatically included.
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, writeConf, partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.deleteQueryTemplate(SomeColumns())
+    Assert.assertTrue("Delete query should contain USING TIMESTAMP :\"_ts\"",
+      query.contains("USING TIMESTAMP :\"_ts\""))
+  }
+
+  @Test
+  def deleteWithExplicitRealTimestampPlaceholderShouldNotTreatPlaceholderAsKeyColumn(): Unit = {
+    val connector = createConnector()
+    val writeTs = ColumnDef("write_ts", RegularColumn, BigIntType)
+    val tableDef = createTableDef(regularColumns = Seq(writeTs))
+    val writeConf = WriteConf(timestamp = TimestampOption.perRow("write_ts"))
+
+    val writer = TableWriter[(Int, Int, Long)](
+      connector, tableDef, SomeColumns("pk", "ck", "write_ts"), writeConf,
+      partitionKeyOnly = true, partitions = Array.empty, tokenRangeAcc = None, isDelete = true)
+
+    val query = writer.deleteQueryTemplate(SomeColumns())
+
+    Assert.assertEquals(Vector("pk", "ck"), writer.columnNames)
+    Assert.assertTrue("Delete query should use the real column as the per-row timestamp placeholder",
+      query.contains("USING TIMESTAMP :write_ts"))
+    Assert.assertFalse("Timestamp placeholder should not be used as a DELETE key column",
+      query.contains("write_ts\" = :\"write_ts"))
+  }
+
+  @Test
+  def directDeleteQueryShouldNotTreatExplicitRealTimestampPlaceholderAsKeyColumn(): Unit = {
+    val connector = createConnector()
+    val writeTs = ColumnDef("write_ts", RegularColumn, BigIntType)
+    val tableDef = createTableDef(regularColumns = Seq(writeTs))
+    val writeConf = WriteConf(timestamp = TimestampOption.perRow("write_ts"))
+
+    val writer = TableWriter[(Int, Int, Long)](
+      connector, tableDef, SomeColumns("pk", "ck", "write_ts"), writeConf,
+      partitionKeyOnly = true, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.deleteQueryTemplate(SomeColumns())
+
+    Assert.assertTrue("Delete query should use the real column as the per-row timestamp placeholder",
+      query.contains("USING TIMESTAMP :write_ts"))
+    Assert.assertFalse("Timestamp placeholder should not be used as a DELETE key column",
+      query.contains("write_ts\" = :\"write_ts"))
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def deleteQueryTemplateShouldRejectCollectionColumnNameInDeleteColumns(): Unit = {
+    val connector = createConnector()
+    val regular = ColumnDef("value", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(regular))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, WriteConf(), partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    writer.deleteQueryTemplate(SomeColumns("value".append))
+  }
+
+  @Test
+  def deleteQueryTemplateShouldAllowCollectionOverwriteInDeleteColumns(): Unit = {
+    val connector = createConnector()
+    val setColumn = ColumnDef("scol", RegularColumn, SetType(TextType))
+    val tableDef = createTableDef(regularColumns = Seq(setColumn))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, WriteConf(), partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.deleteQueryTemplate(SomeColumns("scol".overwrite))
+    Assert.assertTrue("DELETE should include the collection column", query.contains("\"scol\""))
+  }
+
+  @Test
+  def deleteQueryTemplateShouldRejectExplicitPrimaryKeyColumnsAsDeleteColumns(): Unit = {
+    val connector = createConnector()
+    val tableDef = createTableDef()
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, WriteConf(), partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    try {
+      writer.deleteQueryTemplate(SomeColumns("pk"))
+      Assert.fail("Expected IllegalArgumentException for primary key columns in deleteColumns")
+    } catch {
+      case e: IllegalArgumentException =>
+        Assert.assertTrue(e.getMessage.contains("Primary key columns cannot be specified as delete columns"))
+    }
+  }
+
+  @Test
+  def insertQueryTemplateShouldIncludeIfNotExistsWithTtlAndTimestamp(): Unit = {
+    val connector = createConnector()
+    val regular = ColumnDef("value", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(regular))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, AllColumns,
+      WriteConf(ifNotExists = true, ttl = TTLOption.constant(100),
+        timestamp = TimestampOption.constant(1400000000000L)),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.queryTemplateUsingInsert
+    Assert.assertTrue("INSERT should contain IF NOT EXISTS",
+      query.contains("IF NOT EXISTS"))
+    Assert.assertTrue("INSERT should contain USING TTL 100 AND TIMESTAMP 1400000000000",
+      query.contains("USING TTL 100 AND TIMESTAMP 1400000000000"))
+    // IF NOT EXISTS must appear before USING clause in valid CQL
+    val ifNotExistsIdx = query.indexOf("IF NOT EXISTS")
+    val usingIdx = query.indexOf("USING")
+    Assert.assertTrue("IF NOT EXISTS should appear before USING clause",
+      ifNotExistsIdx < usingIdx)
+  }
+
+  @Test
+  def forDeleteShouldStripIfNotExistsIgnoreNullsAndStaticTtl(): Unit = {
+    val writeConf = WriteConf(
+      ifNotExists = true,
+      ignoreNulls = true,
+      ttl = TTLOption.constant(100),
+      timestamp = TimestampOption.constant(1400000000000L))
+    val deleteConf = writeConf.forDelete
+
+    Assert.assertFalse("forDelete should strip ifNotExists", deleteConf.ifNotExists)
+    Assert.assertFalse("forDelete should strip ignoreNulls", deleteConf.ignoreNulls)
+    // Static TTL is stripped because CQL DELETE does not support TTL
+    Assert.assertEquals("forDelete should strip static TTL", TTLOption.defaultValue, deleteConf.ttl)
+    Assert.assertEquals("forDelete should preserve timestamp",
+      TimestampOption.constant(1400000000000L), deleteConf.timestamp)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def shouldThrowWhenTtlPlaceholderCollidesWithAutoTimestampParam(): Unit = {
+    val connector = createConnector()
+    val regular = ColumnDef("value", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(regular))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, AllColumns,
+      WriteConf(ttl = TTLOption.perRow(TableWriter.AutoTimestampParam)),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    writer.queryTemplateUsingUpdate
+  }
+
+  @Test
+  def updateQueryShouldAlwaysIncludeAutoTimestamp(): Unit = {
+    val connector = createConnector()
+    val regular = ColumnDef("value", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(regular))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, AllColumns, WriteConf(),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.queryTemplateUsingUpdate
+    Assert.assertTrue("UPDATE should contain auto-timestamp even without collection behaviors",
+      query.contains(s"USING TIMESTAMP :${TableWriter.AutoTimestampParam}"))
+  }
+
+  @Test
+  def deleteQueryTemplateShouldGiveDeleteSpecificErrorForMissingColumns(): Unit = {
+    val connector = createConnector()
+    val tableDef = createTableDef()
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, WriteConf(), partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    try {
+      writer.deleteQueryTemplate(SomeColumns("nonexistent"))
+      Assert.fail("Expected IllegalArgumentException for nonexistent delete column")
+    } catch {
+      case e: IllegalArgumentException =>
+        Assert.assertTrue("Error should mention DELETE",
+          e.getMessage.contains("DELETE"))
+        Assert.assertTrue("Error should mention the missing column",
+          e.getMessage.contains("nonexistent"))
+    }
+  }
+
+  @Test
+  def autotsShouldNotCollideWithUserColumnNamedAutots(): Unit = {
+    val connector = createConnector()
+    val regular = ColumnDef("autots", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(regular))
+
+    // Should NOT throw — the internal parameter name no longer collides with "autots"
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, AllColumns, WriteConf(),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.queryTemplateUsingUpdate
+    Assert.assertTrue("UPDATE should contain the user column 'autots'",
+      query.contains("\"autots\""))
+  }
+
+  @Test
+  def insertQueryShouldAllowUserColumnNamedAutoTimestampParam(): Unit = {
+    val connector = createConnector()
+    val regular = ColumnDef(TableWriter.AutoTimestampParam, RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(regular))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, AllColumns, WriteConf(),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.queryTemplateUsingInsert
+    Assert.assertTrue("INSERT should contain the user column named like the internal auto timestamp marker",
+      query.contains(s"\"${TableWriter.AutoTimestampParam}\""))
+  }
+
+  @Test
+  def updateQueryShouldAllowUserColumnNamedAutoTimestampParamWithExplicitTimestamp(): Unit = {
+    val connector = createConnector()
+    val regular = ColumnDef(TableWriter.AutoTimestampParam, RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(regular))
+    val timestamp = 1400000000000L
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, AllColumns, WriteConf(timestamp = TimestampOption.constant(timestamp)),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.queryTemplateUsingUpdate
+    Assert.assertTrue("UPDATE should contain the user column named like the internal auto timestamp marker",
+      query.contains(s"\"${TableWriter.AutoTimestampParam}\""))
+    Assert.assertTrue("UPDATE should use the explicit timestamp instead of the internal marker",
+      query.contains(s"USING TIMESTAMP $timestamp"))
+  }
+
+  @Test
+  def tableDefApplyOverloadShouldRemainSourceCompatible(): Unit = {
+    val connector = createConnector()
+    val tableDef = createTableDef()
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, WriteConf(), checkPartitionKey = true,
+      partitions = Array.empty, tokenRangeAcc = None)
+
+    Assert.assertEquals(Vector("pk", "ck"), writer.columnNames)
+  }
+
+  @Test
+  def keyspaceApplyOverloadShouldKeepLegacyBinarySignature(): Unit = {
+    val legacySignature = Seq(
+      classOf[CassandraConnector],
+      classOf[String],
+      classOf[String],
+      classOf[ColumnSelector],
+      classOf[WriteConf],
+      java.lang.Boolean.TYPE,
+      classOf[Array[Partition]],
+      classOf[Option[_]],
+      classOf[RowWriterFactory[_]]).map(_.getName)
+
+    val hasLegacySignature = TableWriter.getClass.getMethods.exists { method =>
+      method.getName == "apply" && method.getParameterTypes.map(_.getName).toSeq == legacySignature
+    }
+
+    Assert.assertTrue(
+      "TableWriter.apply(connector, keyspace, table, columns, writeConf, checkPartitionKey, partitions, tokenRangeAcc) " +
+        "must remain available for callers compiled against previous releases",
+      hasLegacySignature)
+  }
+
+  @Test
+  def forDeleteShouldRejectAllColumnsAsKeyColumns(): Unit = {
+    val regular = ColumnDef("value", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(regular))
+
+    try {
+      TableWriter.validateDeleteSelectors(tableDef, SomeColumns(), AllColumns)
+      Assert.fail("Expected AllColumns to be rejected when the table has non-primary-key columns")
+    } catch {
+      case e: IllegalArgumentException =>
+        Assert.assertTrue(e.getMessage.contains("AllColumns cannot be used as keyColumns"))
+    }
+  }
+
+  @Test
+  def forDeleteShouldAllowAllColumnsAsKeyColumnsOnPrimaryKeyOnlyTable(): Unit = {
+    val tableDef = createTableDef()
+
+    TableWriter.validateDeleteSelectors(tableDef, SomeColumns(), AllColumns)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def forDeleteShouldRejectPrimaryKeyColumnsAsDeleteColumns(): Unit = {
+    TableWriter.validateDeleteSelectors(createTableDef(), PrimaryKeyColumns, PrimaryKeyColumns)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def forDeleteShouldRejectPartitionKeyColumnsAsDeleteColumns(): Unit = {
+    TableWriter.validateDeleteSelectors(createTableDef(), PartitionKeyColumns, PrimaryKeyColumns)
+  }
+
+  @Test
+  def deleteAllColumnsShouldIncludeRealColumnWhenPlaceholderNameMatchesRealColumn(): Unit = {
+    val connector = createConnector()
+    val ttlCol = ColumnDef("ttl_col", RegularColumn, IntType)
+    val data = ColumnDef("data", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(ttlCol, data))
+    val writeConf = WriteConf(ttl = TTLOption.perRow("ttl_col"))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, writeConf, partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.deleteQueryTemplate(AllColumns)
+    Assert.assertTrue("DELETE should include real column ttl_col even though it matches placeholder name",
+      query.contains("\"ttl_col\""))
+    Assert.assertTrue("DELETE should include data column",
+      query.contains("\"data\""))
+  }
+
+  @Test
+  def deleteSomeColumnsShouldFindRealColumnWhenPlaceholderNameMatchesRealColumn(): Unit = {
+    val connector = createConnector()
+    val ttlCol = ColumnDef("ttl_col", RegularColumn, IntType)
+    val data = ColumnDef("data", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(ttlCol, data))
+    val writeConf = WriteConf(ttl = TTLOption.perRow("ttl_col"))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, writeConf, partitionKeyOnly = true,
+      partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    // Should not throw — ttl_col is a real column even though it matches the placeholder name
+    val query = writer.deleteQueryTemplate(SomeColumns("ttl_col"))
+    Assert.assertTrue("DELETE should reference ttl_col", query.contains("\"ttl_col\""))
+  }
+
+  @Test
+  def insertQueryShouldKeepRealColumnWhenTtlPlaceholderNameMatchesColumn(): Unit = {
+    val connector = createConnector()
+    val ttlCol = ColumnDef("ttl_col", RegularColumn, IntType)
+    val data = ColumnDef("data", RegularColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(ttlCol, data))
+    val writeConf = WriteConf(ttl = TTLOption.perRow("ttl_col"))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, AllColumns, writeConf,
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.queryTemplateUsingInsert
+    Assert.assertTrue("INSERT should write the real ttl_col column",
+      query.contains("\"ttl_col\""))
+    Assert.assertTrue("INSERT should still use ttl_col as the per-row TTL placeholder",
+      query.contains("USING TTL :ttl_col"))
+  }
+
+  @Test
+  def insertQueryShouldNotWriteRealColumnWhenOnlyAutoSelectedAsTtlPlaceholder(): Unit = {
+    val connector = createConnector()
+    val ttlCol = ColumnDef("ttl_col", RegularColumn, IntType)
+    val tableDef = createTableDef(regularColumns = Seq(ttlCol))
+    val writeConf = WriteConf(ttl = TTLOption.perRow("ttl_col"))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, PrimaryKeyColumns, writeConf,
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.queryTemplateUsingInsert
+    Assert.assertFalse("INSERT should not write ttl_col unless selected as a table column",
+      query.contains("\"ttl_col\""))
+    Assert.assertTrue("INSERT should still bind ttl_col as the per-row TTL placeholder",
+      query.contains("USING TTL :ttl_col"))
+  }
+
+  @Test
+  def updateQueryShouldKeepRealColumnWhenTtlPlaceholderNameMatchesColumn(): Unit = {
+    val connector = createConnector()
+    val ttlCol = ColumnDef("ttl_col", RegularColumn, IntType)
+    val setColumn = ColumnDef("scol", RegularColumn, SetType(TextType))
+    val tableDef = createTableDef(regularColumns = Seq(ttlCol, setColumn))
+    val writeConf = WriteConf(ttl = TTLOption.perRow("ttl_col"))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, SomeColumns("pk", "ck", "ttl_col", "scol".append), writeConf,
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    val query = writer.queryTemplateUsingUpdate
+    Assert.assertTrue("UPDATE should write the real ttl_col column",
+      query.contains("\"ttl_col\" = :\"ttl_col\""))
+    Assert.assertTrue("UPDATE should still use ttl_col as the per-row TTL placeholder",
+      query.contains("USING TTL :ttl_col"))
+  }
+
+  @Test
+  def staticColumnWriteWithPerRowTimestampShouldNotRequireClusteringKey(): Unit = {
+    val connector = createConnector()
+    val staticCol = ColumnDef("static_value", StaticColumn, TextType)
+    val tableDef = createTableDef(regularColumns = Seq(staticCol))
+
+    val writer = TableWriter[CassandraRow](
+      connector, tableDef, SomeColumns("pk", "static_value"),
+      WriteConf(timestamp = TimestampOption.perRow("write_ts")),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)
+
+    Assert.assertEquals(Vector("pk", "static_value"), writer.columnNames)
+    Assert.assertTrue("INSERT should use the per-row timestamp placeholder",
+      writer.queryTemplateUsingInsert.contains("USING TIMESTAMP :write_ts"))
+  }
+
+  @Test
+  def counterTableWithPerRowTtlShouldNotAutoSelectIgnoredTtlPlaceholder(): Unit = {
+    val connector = createConnector()
+    val counter = ColumnDef("c", RegularColumn, CounterType)
+    val pk = ColumnDef("pk", PartitionKeyColumn, IntType)
+    val tableDef = TableDef("test_ks", "test_counters", Seq(pk), Seq.empty, Seq(counter))
+    val recordingFactory = new RecordingRowWriterFactory
+
+    TableWriter[CassandraRow](
+      connector, tableDef, AllColumns, WriteConf(ttl = TTLOption.perRow("ttl_col")),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)(recordingFactory)
+
+    Assert.assertEquals(Vector("pk", "c"), recordingFactory.selectedColumns.map(_.columnName))
+  }
+
+  @Test
+  def counterTableWithPerRowTimestampShouldNotAutoSelectIgnoredTimestampPlaceholder(): Unit = {
+    val connector = createConnector()
+    val counter = ColumnDef("c", RegularColumn, CounterType)
+    val pk = ColumnDef("pk", PartitionKeyColumn, IntType)
+    val tableDef = TableDef("test_ks", "test_counters", Seq(pk), Seq.empty, Seq(counter))
+    val recordingFactory = new RecordingRowWriterFactory
+
+    TableWriter[CassandraRow](
+      connector, tableDef, AllColumns, WriteConf(timestamp = TimestampOption.perRow("ts_col")),
+      partitionKeyOnly = false, partitions = Array.empty, tokenRangeAcc = None, isDelete = false)(recordingFactory)
+
+    Assert.assertEquals(Vector("pk", "c"), recordingFactory.selectedColumns.map(_.columnName))
+  }
+
+}

--- a/connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
@@ -19,7 +19,7 @@
 package com.datastax.spark.connector.writer
 
 import com.datastax.oss.driver.api.core.DefaultConsistencyLevel
-import com.datastax.spark.connector.{BytesInBatch, RowsInBatch}
+import com.datastax.spark.connector.{BytesInBatch, PrimaryKeyColumns, RowsInBatch, SomeColumns}
 import org.apache.spark.SparkConf
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -96,5 +96,52 @@ class WriteConfTest extends FlatSpec with Matchers {
     writeConf.batchGroupingBufferSize should be(30000)
   }
 
+  it should "keep TTL option placeholder in forDelete config for positional alignment" in {
+    val conf = WriteConf(ttl = TTLOption.perRow("_ttl")).forDelete
+    // TTL is kept in the delete config so option-placeholder columns remain available
+    // for positional alignment in tuple-based RDDs. The DELETE template omits TTL.
+    conf.optionPlaceholders should contain("_ttl")
+  }
+
+  it should "keep per-row TTL and timestamp in forDelete config" in {
+    val wc = WriteConf(
+      ttl = TTLOption.perRow("_ttl"),
+      timestamp = TimestampOption.perRow("_ts"))
+    val conf = wc.forDelete
+    // TTL and timestamp are kept so that the RowWriter preserves tuple-positional mapping
+    conf.ttl should be(TTLOption.perRow("_ttl"))
+    conf.timestamp should be(TimestampOption.perRow("_ts"))
+  }
+
+  it should "strip ifNotExists and ignoreNulls in forDelete" in {
+    val conf = WriteConf(ifNotExists = true, ignoreNulls = true).forDelete
+    conf.ifNotExists should be(false)
+    conf.ignoreNulls should be(false)
+  }
+
+  it should "strip static TTL in forDelete but preserve per-row TTL" in {
+    val staticConf = WriteConf(ttl = TTLOption.constant(100)).forDelete
+    staticConf.ttl should be(TTLOption.defaultValue)
+
+    val perRowConf = WriteConf(ttl = TTLOption.perRow("_ttl")).forDelete
+    perRowConf.ttl should be(TTLOption.perRow("_ttl"))
+  }
+
+  it should "reject duplicate per-row placeholder names for TTL and timestamp" in {
+    val ex = intercept[IllegalArgumentException] {
+      WriteConf(ttl = TTLOption.perRow("x"), timestamp = TimestampOption.perRow("x"))
+    }
+    ex.getMessage should include("different names")
+  }
+
+  it should "keep the legacy optionsAsColumns function accessor" in {
+    val method = classOf[WriteConf].getMethod("optionsAsColumns")
+    method.getReturnType.getName should be("scala.Function2")
+
+    val optionsAsColumns = method.invoke(WriteConf(ttl = TTLOption.perRow("ttl_col")))
+      .asInstanceOf[(String, String) => Seq[com.datastax.spark.connector.cql.ColumnDef]]
+
+    optionsAsColumns("ks", "tbl").map(_.columnName) should contain("ttl_col")
+  }
 
 }

--- a/doc/5_saving.md
+++ b/doc/5_saving.md
@@ -524,10 +524,12 @@ interpreted as Primary Key Constraints.
 `keyColumns: ColumnSelector`  optional parameter allows to manually specify key columns. That allows omitting
 some or all cluster keys for range deletes.
 
-`deleteColumns` and `keyColumns` could not be specified togather as Cassandra does not support range deletes of specific columns
+`deleteColumns` and `keyColumns` can be specified together when `keyColumns` identifies the full primary key needed
+for the requested delete. Range deletes of non-static columns are not supported by Cassandra.
 
-`deleteFromCassandra` uses the same WriteConf and configuration options as `saveToCassandra`,
- for example the timestamp can be passed as WriteConf parameter to delete only records older then the timestamp
+`deleteFromCassandra` uses the same WriteConf execution settings as `saveToCassandra`; for example, the timestamp
+can be passed as a WriteConf parameter to delete only records older than the timestamp. Cassandra does not support
+TTL or `IF NOT EXISTS` on deletes, so those write options are ignored for delete statements.
 
 #### Example Deleting All Rows in a Table Based on a Condition
 


### PR DESCRIPTION
## Summary

Re-applies [apache/cassandra-spark-connector#1142](https://github.com/apache/cassandra-spark-connector/pull/1142) which was merged upstream in 2017 but lost during the 2019 directory restructuring (`spark-cassandra-connector/` → `connector/`).

Closes https://github.com/scylladb/spark-scylladb-connector/issues/95

### Changes

- Thread `WriteConf` (TTL and TIMESTAMP) through `deleteFromCassandra` and update query templates so that DELETE honours TIMESTAMP (ignoring TTL) and UPDATE uses TTL + TIMESTAMP via `USING` clauses
- Extend `BoundStatementBuilder` to bind timestamp/TTL parameters for delete and update operations
- Extract `timestampSpec`, `ttlEnabled`, and `optionsSpec` as shared lazy vals in `TableWriter`
- Log a warning when TTL is configured for DELETE (TTL is not supported on deletes)

### Notes

- The Scylla-specific auto-timestamp logic in `queryTemplateUsingUpdate` (for [#26](https://github.com/scylladb/spark-scylladb-connector/issues/26)) is preserved unchanged
- Replaced upstream's `org.joda.time.DateTime` usage in tests with `java.time.ZonedDateTime` (UTC)

## Test plan

- [x] Unit tests pass (`TableWriterTest`, `WriteConfTest`)
- [x] Integration tests pass for delete with timestamp, per-row timestamp, column-level delete, AllColumns delete
- [x] Integration tests pass for streaming delete with WriteConf timestamp
- [x] Verify TTL is correctly ignored in DELETE statements
- [x] CI/CD pipeline passes