### PR TITLE
address null value processing in TupleValue

### DIFF
--- a/driver/src/main/scala/com/datastax/spark/connector/types/TupleType.scala
+++ b/driver/src/main/scala/com/datastax/spark/connector/types/TupleType.scala
@@ -85,7 +85,7 @@ case class TupleType(componentTypes: TupleFieldDef*)
   private lazy val valuesSeqConverter = scala.util.Try(TypeConverter.forType[ValuesSeqAdapter]).toOption
 
   def converterToCassandra(componentConverters: IndexedSeq[TypeConverter[_ <: AnyRef]]) = {
-    new TypeConverter[TupleValue] {
+    new NullableTypeConverter[TupleValue] {
 
       override def targetTypeTag = TupleValue.TypeTag
 

--- a/driver/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
+++ b/driver/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
@@ -27,6 +27,7 @@ import java.time.{LocalDate, LocalTime, ZoneId, ZoneOffset}
 import java.util.{Date, GregorianCalendar, UUID}
 
 import com.datastax.oss.driver.api.core.data.CqlDuration
+import com.datastax.spark.connector.TupleValue
 
 import scala.collection.immutable.{TreeMap, TreeSet}
 import scala.reflect.runtime.universe._
@@ -654,6 +655,15 @@ class TypeConverterTest {
     val chainedConverter2 = SerializationUtils.roundtrip(chainedConverter)
     assertEquals(1, chainedConverter2.convert(1))
     assertEquals(2, chainedConverter2.convert("2"))
+  }
+
+  @Test
+  def testTupleTypeConverterToCassandraHandlesNull(): Unit = {
+    val tupleType = TupleType(
+      TupleFieldDef(0, IntType),
+      TupleFieldDef(1, TextType))
+    val converter = tupleType.converterToCassandra
+    assertNull(converter.convert(null))
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR is to address the issue reported in https://github.com/scylladb/scylla-migrator/issues/230. 

The issue is caused by TupleType.converterToCassandra which extends TypeConverter[T] that throws TypeConversionException when the input is null.

As the fix, it should extend NullableTypeConverter[T] to override convert() to return null.asInstanceOf[T] for null input.

## Test plan

The new test testTupleTypeConverterToCassandraHandlesNull is added in the PR to test the scenario.

## Checklist

- [X] I have performed a self-review of my own code
- [X] All unit tests pass (`make test-unit`)
- [X] Linting passes (`make lint`)
- [X] Integration test results reviewed (if applicable)
- [X] No new compiler warnings introduced
