### PR TITLE
GH-98: Apply write attributes to final statements

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+Unreleased
+ * Fix batched writes carrying consistency level on child statements,
+   avoiding DefaultBatchStatement warnings (#98)
+
 3.5.1
  * Support for Vector type available in Cassandra 5.0 (SPARKC-706)
  * Upgrade Cassandra Java Driver to 4.18.1, support Cassandra 5.0 in test framework (SPARKC-710)

--- a/connector/src/it/scala/com/datastax/spark/connector/writer/GroupingBatchBuilderSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/writer/GroupingBatchBuilderSpec.scala
@@ -48,7 +48,10 @@ class GroupingBatchBuilderSpec extends SparkCassandraITFlatSpecBase with Default
       rowWriter,
       stmt,
       protocolVersion = protocolVersion)
-    val batchStmtBuilder = new BatchStatementBuilder(DefaultBatchType.UNLOGGED, DefaultConsistencyLevel.LOCAL_ONE)
+    val batchStmtBuilder = new BatchStatementBuilder(
+      DefaultBatchType.UNLOGGED,
+      DefaultConsistencyLevel.LOCAL_ONE,
+      isIdempotent = true)
     new GroupingBatchBuilder[(Int, String)](
       boundStmtBuilder,
       batchStmtBuilder,

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/BatchStatementBuilder.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/BatchStatementBuilder.scala
@@ -24,18 +24,21 @@ import com.datastax.spark.connector.util.Logging
 
 private[connector] class BatchStatementBuilder(
   val batchType: BatchType,
-  val consistencyLevel: ConsistencyLevel) extends Logging {
+  val consistencyLevel: ConsistencyLevel,
+  val isIdempotent: Boolean) extends Logging {
 
   /** Converts a sequence of statements into a batch if its size is greater than 1.
-    * Sets the routing key and consistency level. */
+    * Sets write attributes on the final executable statement. */
   def maybeCreateBatch(stmts: scala.collection.Seq[RichBoundStatementWrapper]): RichStatement = {
     require(stmts.nonEmpty, "Statements list cannot be empty")
     val stmt = stmts.head
 
     if (stmts.size == 1) {
-      stmt.setConsistencyLevel(consistencyLevel)
+      stmt
+        .setConsistencyLevel(consistencyLevel)
+        .setIdempotent(isIdempotent)
     } else {
-      new RichBatchStatementWrapper(batchType, consistencyLevel, stmts)
+      new RichBatchStatementWrapper(batchType, consistencyLevel, isIdempotent, stmts)
     }
   }
 

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/RichStatement.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/RichStatement.scala
@@ -66,6 +66,11 @@ private[connector] class RichBoundStatementWrapper(initStatement: BoundStatement
     this
   }
 
+  def setIdempotent(isIdempotent: Boolean): RichBoundStatementWrapper = {
+    _stmt = _stmt.setIdempotent(isIdempotent)
+    this
+  }
+
   override def stmt: BoundStatement = _stmt
 
   override def executeAs(executeAs: Option[String]): RichStatement = {
@@ -77,10 +82,14 @@ private[connector] class RichBoundStatementWrapper(initStatement: BoundStatement
 private[connector] class RichBatchStatementWrapper(
     batchType: BatchType,
     consistencyLevel: ConsistencyLevel,
+    isIdempotent: Boolean,
     stmts: scala.collection.Seq[RichBoundStatementWrapper])
   extends RichStatement {
 
-  private var _stmt = BatchStatement.newInstance(batchType, stmts.view.map(_.stmt).toSeq:_*).setConsistencyLevel(consistencyLevel)
+  private var _stmt = BatchStatement
+    .newInstance(batchType, stmts.view.map(_.stmt).toSeq:_*)
+    .setConsistencyLevel(consistencyLevel)
+    .setIdempotent(isIdempotent)
 
   override val bytesCount: Int = stmts.view.map(_.bytesCount).sum
 

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -170,8 +170,6 @@ class TableWriter[T] private (
   private def prepareStatement(queryTemplate:String, session: CqlSession): PreparedStatement = {
     try {
       val stmt = SimpleStatement.newInstance(queryTemplate)
-        .setIdempotent(isIdempotent)
-        .setConsistencyLevel(writeConf.consistencyLevel)
       session.prepare(stmt)
     }
     catch {
@@ -242,7 +240,10 @@ class TableWriter[T] private (
         protocolVersion = protocolVersion,
         ignoreNulls = writeConf.ignoreNulls)
 
-      val batchStmtBuilder = new BatchStatementBuilder(batchType, writeConf.consistencyLevel)
+      val batchStmtBuilder = new BatchStatementBuilder(
+        batchType,
+        writeConf.consistencyLevel,
+        isIdempotent)
       val batchKeyGenerator = batchRoutingKey(session)
       val batchBuilder = new GroupingBatchBuilderBase(boundStmtBuilder, batchStmtBuilder, batchKeyGenerator,
         writeConf.batchSize, writeConf.batchGroupingBufferSize)

--- a/connector/src/test/scala/com/datastax/spark/connector/writer/BatchStatementBuilderTest.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/writer/BatchStatementBuilderTest.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.spark.connector.writer
+
+import com.datastax.oss.driver.api.core.DefaultConsistencyLevel
+import com.datastax.oss.driver.api.core.cql.{BatchStatement, BoundStatement, DefaultBatchType}
+import org.junit.Assert._
+import org.junit.Test
+import org.mockito.Mockito._
+
+import scala.jdk.CollectionConverters._
+
+class BatchStatementBuilderTest {
+
+  private def richBoundStatement: RichBoundStatementWrapper = {
+    val statement = mock(classOf[BoundStatement])
+    when(statement.getConsistencyLevel).thenReturn(null)
+    when(statement.getSerialConsistencyLevel).thenReturn(null)
+    new RichBoundStatementWrapper(statement)
+  }
+
+  @Test
+  def multiStatementBatchCarriesConsistencyAndIdempotenceOnBatch(): Unit = {
+    val builder = new BatchStatementBuilder(
+      DefaultBatchType.UNLOGGED,
+      DefaultConsistencyLevel.QUORUM,
+      isIdempotent = true)
+
+    val richStatement = builder.maybeCreateBatch(Seq(richBoundStatement, richBoundStatement))
+    assertTrue(richStatement.isInstanceOf[RichBatchStatementWrapper])
+
+    val batch = richStatement.stmt.asInstanceOf[BatchStatement]
+    assertEquals(DefaultConsistencyLevel.QUORUM, batch.getConsistencyLevel)
+    assertEquals(java.lang.Boolean.TRUE, batch.isIdempotent)
+    batch.asScala.foreach { child =>
+      assertNull(child.getConsistencyLevel)
+      assertNull(child.getSerialConsistencyLevel)
+    }
+  }
+
+  @Test
+  def singleStatementCarriesConsistencyAndIdempotenceOnBoundStatement(): Unit = {
+    val initialStatement = mock(classOf[BoundStatement])
+    val consistencyStatement = mock(classOf[BoundStatement])
+    val updatedStatement = mock(classOf[BoundStatement])
+    when(initialStatement.setConsistencyLevel(DefaultConsistencyLevel.QUORUM))
+      .thenReturn(consistencyStatement)
+    when(consistencyStatement.setIdempotent(true))
+      .thenReturn(updatedStatement)
+    val wrapper = new RichBoundStatementWrapper(initialStatement)
+    val builder = new BatchStatementBuilder(
+      DefaultBatchType.UNLOGGED,
+      DefaultConsistencyLevel.QUORUM,
+      isIdempotent = true)
+
+    val richStatement = builder.maybeCreateBatch(Seq(wrapper))
+
+    assertSame(wrapper, richStatement)
+    assertSame(updatedStatement, wrapper.stmt)
+    verify(initialStatement).setConsistencyLevel(DefaultConsistencyLevel.QUORUM)
+    verify(initialStatement, never()).setIdempotent(true)
+    verify(consistencyStatement).setIdempotent(true)
+  }
+}


### PR DESCRIPTION
## Description

Fixes #98.

The old write path applied consistency and idempotence to prepared write statements. The Scylla Java driver copies those attributes onto bound children, so when the connector grouped multiple rows into a `DefaultBatchStatement`, the driver warned that child consistency levels are ignored by batches.

This branch keeps prepared statements as plain query templates and applies write attributes only to the final `BoundStatement` or `BatchStatement` that is actually executed.

## Verification

I ran the same repro on:
- `dkropachev/avoid-child-cl-batch-warning`: no `DefaultBatchStatement` warning
- `scylla-4.x` at `a9871c0f` (this repo has no `master` ref; this is the old baseline): warning appears twice for the batched write

Command:

```text
./sbt/sbt 'connector / IntegrationTest / testOnly com.datastax.spark.connector.writer.BatchWarningReproSpec'
```

The only other log line in both runs is the unrelated server-side aggregation warning from `SELECT count(*)`.

The branch is already a single commit, so there was nothing to squash.
