### PR TITLE
fix: bind duplicate write markers by index

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ Unreleased
 3.5.1
  * Support for Vector type available in Cassandra 5.0 (SPARKC-706)
  * Upgrade Cassandra Java Driver to 4.18.1, support Cassandra 5.0 in test framework (SPARKC-710)
+ * Bind duplicate and case-sensitive write bind markers by index (#100)
 
 3.5.0
  * Support for Apache Spark 3.5 (SPARKC-704)

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
@@ -21,9 +21,11 @@ package com.datastax.spark.connector.writer
 import com.datastax.oss.driver.api.core.`type`.DataType
 import com.datastax.oss.driver.api.core.`type`.codec.TypeCodec
 import com.datastax.oss.driver.api.core.cql.{BoundStatement, PreparedStatement}
-import com.datastax.oss.driver.api.core.{DefaultProtocolVersion, ProtocolVersion}
+import com.datastax.oss.driver.api.core.{CqlIdentifier, DefaultProtocolVersion, ProtocolVersion}
 import com.datastax.spark.connector.types.{ColumnType, Unset}
 import com.datastax.spark.connector.util.{CodecRegistryUtil, Logging}
+
+import scala.jdk.CollectionConverters._
 
 /**
  * Class for binding row-like objects into prepared statements. prefixVals
@@ -39,10 +41,26 @@ private[connector] class BoundStatementBuilder[T](
     val autoTimestampParam: Option[String] = None) extends Logging {
 
   private val columnNames = rowWriter.columnNames.toIndexedSeq
-  private val columnTypes = columnNames.map(preparedStmt.getVariableDefinitions.get(_).getType)
-  private val converters = columnTypes.map(ColumnType.converterToCassandra(_))
+  private val variableDefinitions = preparedStmt.getVariableDefinitions
+
+  /** Precomputed variable indices for each column in the prepared statement.
+    * A column name can occur more than once when a real column is also used as
+    * a per-row TTL/TIMESTAMP placeholder; bind every occurrence by index so
+    * each marker uses its own CQL type and is included in size accounting.
+    * Prefix values are bound positionally by preparedStmt.bind and must not be
+    * overwritten when their marker names collide with row-bound marker names. */
+  private def variableIndicesFor(name: String): Array[Int] = {
+    val exactIndices = variableDefinitions.allIndicesOf(CqlIdentifier.fromInternal(name)).asScala
+    val indices = if (exactIndices.nonEmpty) exactIndices else variableDefinitions.allIndicesOf(name).asScala
+    indices.map(_.toInt).filter(_ >= prefixVals.size).toArray
+  }
+
+  private val varIndices: Array[Array[Int]] = columnNames.map(variableIndicesFor).toArray
+  private val inStatement: Array[Boolean] = varIndices.map(_.nonEmpty)
+  private val columnTypes = varIndices.map(_.map(index => variableDefinitions.get(index).getType))
+  private val converters = columnTypes.map(_.map(ColumnType.converterToCassandra(_)))
   private val buffer = Array.ofDim[Any](columnNames.size)
-  private val cachedCodecs = new Array[TypeCodec[AnyRef]](columnNames.size)
+  private val cachedCodecs = columnTypes.map(types => new Array[TypeCodec[AnyRef]](types.length))
 
   /** Internal auto-timestamp placeholder to bind, if this statement was generated with one. */
   private val autoTimestampVariable: Option[String] =
@@ -80,28 +98,28 @@ private[connector] class BoundStatementBuilder[T](
 
   private def bindColumnNull(
     boundStatement: RichBoundStatementWrapper,
-    columnName: String,
+    variableIndex: Int,
     columnValue: AnyRef,
     codec: TypeCodec[AnyRef]): Unit = {
 
     if (columnValue == Unset || (ignoreNulls && columnValue == null)) {
-      boundStatement.update(s => s.setToNull(columnName))
+      boundStatement.update(s => s.setToNull(variableIndex))
       logUnsetToNullWarning = true
     } else {
-      boundStatement.update(s => s.set(columnName, columnValue, codec))
+      boundStatement.update(s => s.set(variableIndex, columnValue, codec))
     }
   }
 
   private def bindColumnUnset(
     boundStatement: RichBoundStatementWrapper,
-    columnName: String,
+    variableIndex: Int,
     columnValue: AnyRef,
     codec: TypeCodec[AnyRef]): Unit = {
 
     if (columnValue == Unset || (ignoreNulls && columnValue == null)) {
       //Do not bind
     } else {
-      boundStatement.update(s => s.set(columnName, columnValue, codec))
+      boundStatement.update(s => s.set(variableIndex, columnValue, codec))
     }
   }
 
@@ -110,7 +128,7 @@ private[connector] class BoundStatementBuilder[T](
   * we can leave values in the prepared statement unset. If the version is
   * less than V3 then we need to place a `null` in the bound statement.
   */
-  val bindColumn: (RichBoundStatementWrapper, String, AnyRef, TypeCodec[AnyRef]) => Unit = protocolVersion match {
+  val bindColumn: (RichBoundStatementWrapper, Int, AnyRef, TypeCodec[AnyRef]) => Unit = protocolVersion match {
     case pv if pv.getCode() <= DefaultProtocolVersion.V3.getCode => bindColumnNull
     case _ => bindColumnUnset
   }
@@ -130,22 +148,24 @@ private[connector] class BoundStatementBuilder[T](
     rowWriter.readColumnValues(row, buffer)
     val codecRegistry = boundStatement.stmt.codecRegistry()
     var bytesCount = 0
-    for (i <- columnNames.indices) {
-      val converter = converters(i)
-      val columnName = columnNames(i)
-      val columnType = columnTypes(i)
-      val columnValue = converter.convert(buffer(i))
-      val codec = {
-        var c = cachedCodecs(i)
-        if (c == null && columnValue != Unset) {
-          c = CodecRegistryUtil.codecFor(codecRegistry, columnType, columnValue)
-          cachedCodecs(i) = c
+    for (i <- columnNames.indices if inStatement(i)) {
+      for (j <- varIndices(i).indices) {
+        val converter = converters(i)(j)
+        val variableIndex = varIndices(i)(j)
+        val columnType = columnTypes(i)(j)
+        val columnValue = converter.convert(buffer(i))
+        val codec = {
+          var c = cachedCodecs(i)(j)
+          if (c == null && columnValue != Unset) {
+            c = CodecRegistryUtil.codecFor(codecRegistry, columnType, columnValue)
+            cachedCodecs(i)(j) = c
+          }
+          c
         }
-        c
+        bindColumn(boundStatement, variableIndex, columnValue, codec)
+        val serializedValue = boundStatement.stmt.getBytesUnsafe(variableIndex)
+        if (serializedValue != null) bytesCount += serializedValue.remaining()
       }
-      bindColumn(boundStatement, columnName, columnValue, codec)
-      val serializedValue = boundStatement.stmt.getBytesUnsafe(i)
-      if (serializedValue != null) bytesCount += serializedValue.remaining()
     }
 
     autoTimestampVariable.foreach { param =>

--- a/connector/src/test/scala/com/datastax/spark/connector/writer/BoundStatementBuilderRegressionTest.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/writer/BoundStatementBuilderRegressionTest.scala
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.spark.connector.writer
+
+import java.nio.ByteBuffer
+import java.util.{Collections => JCollections}
+
+import com.datastax.oss.driver.api.core.{CqlIdentifier, ProtocolVersion}
+import com.datastax.oss.driver.api.core.`type`.codec.registry.CodecRegistry
+import com.datastax.oss.driver.api.core.cql.{ColumnDefinition, ColumnDefinitions, PreparedStatement}
+import com.datastax.oss.driver.internal.core.cql.{DefaultColumnDefinition, DefaultColumnDefinitions, DefaultPreparedStatement}
+import com.datastax.oss.protocol.internal.ProtocolConstants
+import com.datastax.oss.protocol.internal.response.result.{ColumnSpec, RawType}
+import org.junit.{Assert, Test}
+
+import scala.jdk.CollectionConverters._
+
+class BoundStatementBuilderRegressionTest {
+
+  private def columnDefinitions(columns: (String, Int)*): ColumnDefinitions = {
+    DefaultColumnDefinitions.valueOf(columns.zipWithIndex.map { case ((name, dataType), index) =>
+      val columnSpec = new ColumnSpec("ks", "tab", name, index, RawType.PRIMITIVES.get(dataType))
+      new DefaultColumnDefinition(columnSpec, null).asInstanceOf[ColumnDefinition]
+    }.toList.asJava)
+  }
+
+  private def preparedStatementWithVariables(columns: (String, Int)*): PreparedStatement = {
+    new DefaultPreparedStatement(
+      ByteBuffer.wrap(Array[Byte](1)),
+      "test query",
+      columnDefinitions(columns: _*),
+      JCollections.emptyList[java.lang.Integer](),
+      null,
+      columnDefinitions(),
+      CqlIdentifier.fromInternal("ks"),
+      null,
+      JCollections.emptyMap[String, ByteBuffer](),
+      null,
+      null,
+      CqlIdentifier.fromInternal("tab"),
+      null,
+      null,
+      JCollections.emptyMap[String, ByteBuffer](),
+      java.lang.Boolean.TRUE,
+      null,
+      null,
+      0,
+      null,
+      null,
+      false,
+      CodecRegistry.DEFAULT,
+      ProtocolVersion.DEFAULT,
+      false)
+  }
+
+  @Test
+  def shouldBindDuplicateMarkersAndCountEveryOccurrence(): Unit = {
+    val preparedStatement = preparedStatementWithVariables(
+      "id" -> ProtocolConstants.DataType.INT,
+      "ttl_col" -> ProtocolConstants.DataType.INT,
+      "value" -> ProtocolConstants.DataType.VARCHAR,
+      "ttl_col" -> ProtocolConstants.DataType.INT)
+    val rowWriter = new RowWriter[Seq[Any]] {
+      override def columnNames: Seq[String] = Seq("id", "ttl_col", "value")
+      override def readColumnValues(data: Seq[Any], buffer: Array[Any]): Unit =
+        data.zipWithIndex.foreach { case (value, index) => buffer(index) = value }
+    }
+
+    val builder = new BoundStatementBuilder(rowWriter, preparedStatement, protocolVersion = ProtocolVersion.DEFAULT)
+    val bound = builder.bind(Seq(1, 60, "abc"))
+    val ttlMarkerIndices = preparedStatement.getVariableDefinitions.allIndicesOf("ttl_col").asScala
+
+    Assert.assertEquals(2, ttlMarkerIndices.size)
+    ttlMarkerIndices.foreach { index =>
+      Assert.assertNotNull(bound.stmt.getBytesUnsafe(index))
+    }
+    Assert.assertEquals(BoundStatementBuilder.calculateDataSize(bound.stmt), bound.bytesCount)
+  }
+
+  @Test
+  def shouldNotOverwritePrefixValuesWithDuplicateMarkerNames(): Unit = {
+    val preparedStatement = preparedStatementWithVariables(
+      "key" -> ProtocolConstants.DataType.INT,
+      "key" -> ProtocolConstants.DataType.INT)
+    val rowWriter = new RowWriter[Seq[Any]] {
+      override def columnNames: Seq[String] = Seq("key")
+      override def readColumnValues(data: Seq[Any], buffer: Array[Any]): Unit = buffer(0) = data.head
+    }
+
+    val builder = new BoundStatementBuilder(
+      rowWriter,
+      preparedStatement,
+      prefixVals = Seq(99),
+      protocolVersion = ProtocolVersion.DEFAULT)
+    val bound = builder.bind(Seq(7)).stmt
+
+    Assert.assertEquals("The prefix marker must keep the value supplied through prefixVals", 99, bound.getInt(0))
+    Assert.assertEquals("The row marker should use the value read from the row", 7, bound.getInt(1))
+  }
+
+  @Test
+  def shouldKeepQuotedMarkerCaseDistinct(): Unit = {
+    val preparedStatement = preparedStatementWithVariables(
+      "Foo" -> ProtocolConstants.DataType.INT,
+      "foo" -> ProtocolConstants.DataType.INT)
+    val rowWriter = new RowWriter[Seq[Any]] {
+      override def columnNames: Seq[String] = Seq("Foo", "foo")
+      override def readColumnValues(data: Seq[Any], buffer: Array[Any]): Unit =
+        data.zipWithIndex.foreach { case (value, index) => buffer(index) = value }
+    }
+
+    val bound = new BoundStatementBuilder(
+      rowWriter,
+      preparedStatement,
+      protocolVersion = ProtocolVersion.DEFAULT)
+      .bind(Seq(1, 2))
+      .stmt
+
+    Assert.assertEquals(1, bound.getInt(0))
+    Assert.assertEquals(2, bound.getInt(1))
+  }
+
+  @Test
+  def shouldBindUnquotedMixedCaseMarkerNames(): Unit = {
+    val preparedStatement = preparedStatementWithVariables(
+      "id" -> ProtocolConstants.DataType.INT,
+      "ttlcol" -> ProtocolConstants.DataType.INT)
+    val rowWriter = new RowWriter[Seq[Any]] {
+      override def columnNames: Seq[String] = Seq("id", "ttlCol")
+      override def readColumnValues(data: Seq[Any], buffer: Array[Any]): Unit =
+        data.zipWithIndex.foreach { case (value, index) => buffer(index) = value }
+    }
+
+    val bound = new BoundStatementBuilder(
+      rowWriter,
+      preparedStatement,
+      protocolVersion = ProtocolVersion.DEFAULT)
+      .bind(Seq(1, 60))
+      .stmt
+
+    Assert.assertEquals(1, bound.getInt("id"))
+    Assert.assertEquals(60, bound.getInt("ttlcol"))
+  }
+
+  @Test
+  def shouldNotBindAutoTimestampMarkerUnlessRequested(): Unit = {
+    val preparedStatement = preparedStatementWithVariables(
+      "id" -> ProtocolConstants.DataType.INT,
+      TableWriter.AutoTimestampParam -> ProtocolConstants.DataType.BIGINT)
+    val rowWriter = new RowWriter[Seq[Any]] {
+      override def columnNames: Seq[String] = Seq("id")
+      override def readColumnValues(data: Seq[Any], buffer: Array[Any]): Unit = buffer(0) = data.head
+    }
+
+    val bound = new BoundStatementBuilder(
+      rowWriter,
+      preparedStatement,
+      protocolVersion = ProtocolVersion.DEFAULT)
+      .bind(Seq(1))
+      .stmt
+
+    Assert.assertEquals(1, bound.getInt("id"))
+    Assert.assertFalse(bound.isSet(TableWriter.AutoTimestampParam))
+  }
+
+  @Test
+  def shouldBindAutoTimestampMarkerWhenRequested(): Unit = {
+    val preparedStatement = preparedStatementWithVariables(
+      "id" -> ProtocolConstants.DataType.INT,
+      TableWriter.AutoTimestampParam -> ProtocolConstants.DataType.BIGINT)
+    val rowWriter = new RowWriter[Seq[Any]] {
+      override def columnNames: Seq[String] = Seq("id")
+      override def readColumnValues(data: Seq[Any], buffer: Array[Any]): Unit = buffer(0) = data.head
+    }
+
+    val bound = new BoundStatementBuilder(
+      rowWriter,
+      preparedStatement,
+      protocolVersion = ProtocolVersion.DEFAULT,
+      autoTimestampParam = Some(TableWriter.AutoTimestampParam))
+      .bind(Seq(1))
+
+    Assert.assertEquals(1, bound.stmt.getInt("id"))
+    Assert.assertTrue(bound.stmt.isSet(TableWriter.AutoTimestampParam))
+    Assert.assertTrue(bound.stmt.getLong(TableWriter.AutoTimestampParam) > 0L)
+    Assert.assertEquals(BoundStatementBuilder.calculateDataSize(bound.stmt), bound.bytesCount)
+  }
+}


### PR DESCRIPTION
Fixes #100.

This isolates the BoundStatementBuilder marker binding fixes from the SPARKC-505 branch:
- bind all row-bound occurrences of duplicate marker names by index;
- avoid overwriting prefix-bound values when marker names collide;
- preserve case-sensitive quoted marker lookup;
- include every bound occurrence in statement size accounting.

Validation:
- repo-ci fast: failed before project tests due the learned command running under Java 8 while the build uses -release:17.