### PR TITLE
fix: quote generated join bind markers

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/JoinHelper.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/JoinHelper.scala
@@ -36,6 +36,9 @@ import scala.collection.mutable
 
 object JoinHelper extends Logging {
 
+  private def bindMarker(columnName: String): String =
+    s":${CqlIdentifier.fromInternal(columnName).asCql(true)}"
+
   /**
    * Determines which join columns are partition key columns and which are clustering columns.
    * Returns (partitionKeyJoinColumns, clusteringJoinColumns) in table definition order.
@@ -77,11 +80,11 @@ object JoinHelper extends Logging {
 
     // Partition key columns use = :name
     val pkWhere = pkCols.map(c =>
-      s"${CqlIdentifier.fromInternal(c.columnName).asCql(true)} = :${c.columnName}")
+      s"${CqlIdentifier.fromInternal(c.columnName).asCql(true)} = ${bindMarker(c.columnName)}")
 
     // All clustering columns except the last use = :name
     val ckEqWhere = ckCols.init.map(c =>
-      s"${CqlIdentifier.fromInternal(c.columnName).asCql(true)} = :${c.columnName}")
+      s"${CqlIdentifier.fromInternal(c.columnName).asCql(true)} = ${bindMarker(c.columnName)}")
 
     // Last clustering column uses IN (?, ?, ...)
     val lastCk = ckCols.last
@@ -144,7 +147,9 @@ object JoinHelper extends Logging {
     logDebug("Generating Single Key Query Prepared Statement String")
     logDebug(s"SelectedColumns : ${queryParts.selectedColumnRefs} -- JoinColumnNames : $joinColumnNames")
     val columns = queryParts.selectedColumnRefs.map(_.cql).mkString(", ")
-    val joinWhere = joinColumnNames.map(name => s"${CqlIdentifier.fromInternal(name).asCql(true)} = :$name")
+    val joinWhere = joinColumnNames.map { name =>
+      s"${CqlIdentifier.fromInternal(name).asCql(true)} = ${bindMarker(name)}"
+    }
     val limitClause = CassandraLimit.limitToClause(queryParts.limitClause)
     val orderBy = queryParts.clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
     val filter = (queryParts.whereClause.predicates ++ joinWhere).mkString(" AND ")
@@ -301,4 +306,3 @@ object JoinHelper extends Logging {
   }
 
 }
-

--- a/connector/src/test/scala/com/datastax/spark/connector/datasource/JoinHelperTest.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/datasource/JoinHelperTest.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.spark.connector.datasource
+
+import com.datastax.spark.connector.{ColumnName, SomeColumns}
+import com.datastax.spark.connector.cql.{ClusteringColumn, ColumnDef, PartitionKeyColumn, RegularColumn, TableDef}
+import com.datastax.spark.connector.datasource.ScanHelper.CqlQueryParts
+import com.datastax.spark.connector.rdd.CqlWhereClause
+import com.datastax.spark.connector.types.{IntType, TextType}
+import org.junit.{Assert, Test}
+
+class JoinHelperTest {
+
+  private val tableDef = TableDef(
+    "test_ks",
+    "test_table",
+    Seq(ColumnDef("UserId", PartitionKeyColumn, IntType)),
+    Seq.empty,
+    Seq(ColumnDef("value", RegularColumn, TextType)))
+
+  private val queryParts = CqlQueryParts(
+    selectedColumnRefs = SomeColumns("UserId", "value").selectFrom(tableDef),
+    whereClause = CqlWhereClause.empty)
+
+  @Test
+  def joinQueryShouldQuoteCaseSensitiveBindMarkers(): Unit = {
+    val query = JoinHelper.getJoinQueryString(tableDef, Seq(ColumnName("UserId")), queryParts)
+
+    Assert.assertTrue(query, query.contains("\"UserId\" = :\"UserId\""))
+  }
+
+  @Test
+  def joinInQueryShouldQuoteCaseSensitiveBindMarkers(): Unit = {
+    val tableWithClustering = tableDef.copy(
+      clusteringColumns = Seq(
+        ColumnDef("TenantId", ClusteringColumn(0), IntType),
+        ColumnDef("GroupId", ClusteringColumn(1), IntType)))
+    val inQueryParts = queryParts.copy(
+      selectedColumnRefs = SomeColumns("UserId", "TenantId", "GroupId", "value").selectFrom(tableWithClustering))
+
+    val query = JoinHelper.getJoinInQueryString(
+      tableWithClustering,
+      Seq(ColumnName("UserId"), ColumnName("TenantId"), ColumnName("GroupId")),
+      inQueryParts,
+      inClauseSize = 2)
+
+    Assert.assertTrue(query, query.contains("\"UserId\" = :\"UserId\""))
+    Assert.assertTrue(query, query.contains("\"TenantId\" = :\"TenantId\""))
+    Assert.assertTrue(query, query.contains("\"GroupId\" IN (?, ?)"))
+  }
+}


### PR DESCRIPTION
Fixes #101.

This isolates the join marker quoting fix from the SPARKC-505 branch:
- quote generated bind markers using CqlIdentifier;
- preserve case-sensitive join column names;
- cover both standard join queries and IN-clause batching queries.

Validation:
- not rerun for this split branch; repo-ci fast currently fails before project tests because the learned command runs under Java 8 while the build uses -release:17.