### PR TITLE
fix: ignore counter write option placeholders

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,11 +1,12 @@
 Unreleased
  * Fix batched writes carrying consistency level on child statements,
    avoiding DefaultBatchStatement warnings (#98)
-
+ * Avoid requiring ignored per-row write option placeholders for counter updates (#102)
+ * Avoid auto timestamp bind marker collisions with user columns (#103)
+ 
 3.5.1
  * Support for Vector type available in Cassandra 5.0 (SPARKC-706)
  * Upgrade Cassandra Java Driver to 4.18.1, support Cassandra 5.0 in test framework (SPARKC-710)
- * Avoid auto timestamp bind marker collisions with user columns (#103)
 
 3.5.0
  * Support for Apache Spark 3.5 (SPARKC-704)

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -501,10 +501,19 @@ object TableWriter {
        tokenRangeAcc: Option[TokenRangeAccumulator]): TableWriter[T] = {
 
     val optionColumns = writeConf.optionsAsColumns(tableDef.keyspaceName, tableDef.tableName)
+    val tableHasCounterColumns = tableDef.columns.exists(_.isCounterColumn)
     val tablDefWithMeta = tableDef.copy(regularColumns = tableDef.regularColumns ++ optionColumns)
 
+    val tableDefForSelection = if (tableHasCounterColumns && columnNames == AllColumns) {
+      // Counter UPDATE statements do not support TTL or TIMESTAMP, so per-row
+      // placeholders must not be required unless the caller selected them explicitly.
+      tableDef
+    } else {
+      tablDefWithMeta
+    }
+
     val selectedColumns = columnNames
-      .selectFrom(tablDefWithMeta)
+      .selectFrom(tableDefForSelection)
       .filter(col => !InternalColumns.contains(col.columnName))
     val rowWriter = implicitly[RowWriterFactory[T]].rowWriter(tablDefWithMeta, selectedColumns)
 

--- a/connector/src/test/scala/com/datastax/spark/connector/writer/TableWriterCounterOptionsTest.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/writer/TableWriterCounterOptionsTest.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.spark.connector.writer
+
+import java.net.InetSocketAddress
+
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql._
+import com.datastax.spark.connector.types.{CounterType, IntType}
+import org.junit.{Assert, Test}
+
+class TableWriterCounterOptionsTest {
+
+  private def createConnector(): CassandraConnector = {
+    val contactInfo = IpBasedContactInfo(Set(new InetSocketAddress("127.0.0.1", 9042)))
+    val connectorConf = CassandraConnectorConf(contactInfo)
+    new CassandraConnector(connectorConf)
+  }
+
+  private def counterTableDef: TableDef = {
+    val pk = ColumnDef("pk", PartitionKeyColumn, IntType)
+    val counter = ColumnDef("c", RegularColumn, CounterType)
+    TableDef("test_ks", "test_counters", Seq(pk), Seq.empty, Seq(counter))
+  }
+
+  private class RecordingRowWriterFactory extends RowWriterFactory[CassandraRow] {
+    var selectedColumns: IndexedSeq[ColumnRef] = IndexedSeq.empty
+
+    override def rowWriter(table: TableDef, selectedColumns: IndexedSeq[ColumnRef]): RowWriter[CassandraRow] = {
+      this.selectedColumns = selectedColumns
+      new RowWriter[CassandraRow] {
+        override def columnNames: Seq[String] = selectedColumns.map(_.columnName)
+        override def readColumnValues(data: CassandraRow, buffer: Array[Any]): Unit = ()
+      }
+    }
+  }
+
+  @Test
+  def counterTableWithPerRowTtlShouldNotAutoSelectIgnoredTtlPlaceholder(): Unit = {
+    val recordingFactory = new RecordingRowWriterFactory
+
+    TableWriter[CassandraRow](
+      createConnector(), counterTableDef, AllColumns, WriteConf(ttl = TTLOption.perRow("ttl_col")),
+      checkPartitionKey = false, partitions = Array.empty, tokenRangeAcc = None)(recordingFactory)
+
+    Assert.assertEquals(Vector("pk", "c"), recordingFactory.selectedColumns.map(_.columnName))
+  }
+
+  @Test
+  def counterTableWithPerRowTimestampShouldNotAutoSelectIgnoredTimestampPlaceholder(): Unit = {
+    val recordingFactory = new RecordingRowWriterFactory
+
+    TableWriter[CassandraRow](
+      createConnector(), counterTableDef, AllColumns, WriteConf(timestamp = TimestampOption.perRow("ts_col")),
+      checkPartitionKey = false, partitions = Array.empty, tokenRangeAcc = None)(recordingFactory)
+
+    Assert.assertEquals(Vector("pk", "c"), recordingFactory.selectedColumns.map(_.columnName))
+  }
+}


### PR DESCRIPTION
Fixes #102.

This isolates the counter write option fix from the SPARKC-505 branch:
- do not auto-select synthetic per-row TTL/TIMESTAMP placeholders for counter tables when using AllColumns;
- keep explicit placeholder selection available for positional compatibility;
- leave counter UPDATE CQL free of unsupported TTL/TIMESTAMP clauses.

Validation:
- not rerun for this split branch; repo-ci fast currently fails before project tests because the learned command runs under Java 8 while the build uses -release:17.