### PR TITLE
fix: avoid auto timestamp marker collisions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Unreleased
 3.5.1
  * Support for Vector type available in Cassandra 5.0 (SPARKC-706)
  * Upgrade Cassandra Java Driver to 4.18.1, support Cassandra 5.0 in test framework (SPARKC-710)
+ * Avoid auto timestamp bind marker collisions with user columns (#103)
 
 3.5.0
  * Support for Apache Spark 3.5 (SPARKC-704)

--- a/connector/src/it/scala/com/datastax/spark/connector/writer/BoundStatementBuilderSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/writer/BoundStatementBuilderSpec.scala
@@ -33,14 +33,30 @@ class BoundStatementBuilderSpec extends SparkCassandraITFlatSpecBase with Defaul
     conn.withSessionDo { session =>
       createKeyspace(session, ks)
       session.execute( s"""CREATE TABLE IF NOT EXISTS "$ks".tab (id INT PRIMARY KEY, value TEXT)""")
+      session.execute(
+        s"""CREATE TABLE IF NOT EXISTS "$ks".autots_marker_collision
+           |(id INT PRIMARY KEY, ${TableWriter.AutoTimestampParam} TEXT)""".stripMargin)
     }
   }
 
   lazy val schema = schemaFromCassandra(conn, Some(ks), Some("tab"))
   lazy val rowWriter = RowWriterFactory.defaultRowWriterFactory[(Int, CassandraOption[String])]
     .rowWriter(schema.tables.head, IndexedSeq("id", "value"))
+  lazy val valueRowWriter = RowWriterFactory.defaultRowWriterFactory[(Int, String)]
+    .rowWriter(schema.tables.head, IndexedSeq("id", "value"))
   lazy val ps = conn.withSessionDo(session =>
     session.prepare( s"""INSERT INTO "$ks".tab (id, value) VALUES (?, ?) """))
+  lazy val autoTimestampPs = conn.withSessionDo(session =>
+    session.prepare(
+      s"""UPDATE "$ks".tab USING TIMESTAMP :${TableWriter.AutoTimestampParam}
+         |SET value = :value WHERE id = :id""".stripMargin))
+  lazy val markerCollisionSchema = schemaFromCassandra(conn, Some(ks), Some("autots_marker_collision"))
+  lazy val markerCollisionRowWriter = RowWriterFactory.defaultRowWriterFactory[(Int, String)]
+    .rowWriter(markerCollisionSchema.tables.head, IndexedSeq("id", TableWriter.AutoTimestampParam))
+  lazy val markerCollisionPs = conn.withSessionDo(session =>
+    session.prepare(
+      s"""INSERT INTO "$ks".autots_marker_collision
+         |(id, ${TableWriter.AutoTimestampParam}) VALUES (?, ?)""".stripMargin))
 
   val PVGt4 = Seq(DefaultProtocolVersion.V4, DefaultProtocolVersion.V5, DseProtocolVersion.DSE_V1, DseProtocolVersion.DSE_V2)
   val PVLte3 = Seq(DefaultProtocolVersion.V3)
@@ -86,5 +102,26 @@ class BoundStatementBuilderSpec extends SparkCassandraITFlatSpecBase with Defaul
           ignoreNulls = true)
       }
     }
+  }
+
+  it should "not bind connector_autots unless auto timestamp binding is requested" in {
+    val bsb = new BoundStatementBuilder(
+      markerCollisionRowWriter,
+      markerCollisionPs,
+      protocolVersion = conn.withSessionDo(_.getContext.getProtocolVersion))
+
+    val bound = bsb.bind((1, "user-value")).stmt
+    bound.getString(TableWriter.AutoTimestampParam) should be("user-value")
+  }
+
+  it should "bind connector_autots when auto timestamp binding is requested" in {
+    val bsb = new BoundStatementBuilder(
+      valueRowWriter,
+      autoTimestampPs,
+      protocolVersion = conn.withSessionDo(_.getContext.getProtocolVersion),
+      autoTimestampParam = Some(TableWriter.AutoTimestampParam))
+
+    val bound = bsb.bind((1, "value")).stmt
+    bound.getLong(TableWriter.AutoTimestampParam) should be > 0L
   }
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
@@ -35,7 +35,8 @@ private[connector] class BoundStatementBuilder[T](
     val preparedStmt: PreparedStatement,
     val prefixVals: Seq[Any] = Seq.empty,
     val ignoreNulls: Boolean = false,
-    val protocolVersion: ProtocolVersion) extends Logging {
+    val protocolVersion: ProtocolVersion,
+    val autoTimestampParam: Option[String] = None) extends Logging {
 
   private val columnNames = rowWriter.columnNames.toIndexedSeq
   private val columnTypes = columnNames.map(preparedStmt.getVariableDefinitions.get(_).getType)
@@ -43,12 +44,9 @@ private[connector] class BoundStatementBuilder[T](
   private val buffer = Array.ofDim[Any](columnNames.size)
   private val cachedCodecs = new Array[TypeCodec[AnyRef]](columnNames.size)
 
-  /** Whether the prepared statement contains an auto-timestamp placeholder that
-    * needs to be bound with a unique, incrementing microsecond timestamp per row. */
-  private val hasAutoTimestamp: Boolean = {
-    val varDefs = preparedStmt.getVariableDefinitions
-    (0 until varDefs.size()).exists(i => varDefs.get(i).getName.asInternal() == TableWriter.AutoTimestampParam)
-  }
+  /** Internal auto-timestamp placeholder to bind, if this statement was generated with one. */
+  private val autoTimestampVariable: Option[String] =
+    autoTimestampParam.filter(preparedStmt.getVariableDefinitions.contains)
 
   /** Monotonically incrementing microsecond counter for auto-timestamps.
     * Uses a global counter to guarantee uniqueness across all concurrent
@@ -150,8 +148,9 @@ private[connector] class BoundStatementBuilder[T](
       if (serializedValue != null) bytesCount += serializedValue.remaining()
     }
 
-    if (hasAutoTimestamp) {
-      boundStatement.update(_.setLong(TableWriter.AutoTimestampParam, autoTsCounter.getAndIncrement()))
+    autoTimestampVariable.foreach { param =>
+      boundStatement.update(_.setLong(param, autoTsCounter.getAndIncrement()))
+      bytesCount += 8 // Long = 8 bytes, not counted in the column loop above
     }
 
     boundStatement.bytesCount = bytesCount

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -132,7 +132,9 @@ class TableWriter[T] private (
       writeConf.timestamp match {
         case TimestampOption(PerRowWriteOptionValue(placeholder)) => s" USING TIMESTAMP :$placeholder"
         case TimestampOption(StaticWriteOptionValue(value)) => s" USING TIMESTAMP $value"
-        case _ => s" USING TIMESTAMP :${TableWriter.AutoTimestampParam}"
+        case _ =>
+          TableWriter.checkAutoTimestampCollisions(columnNames, writeConf)
+          s" USING TIMESTAMP :${TableWriter.AutoTimestampParam}"
       }
     }
 
@@ -144,6 +146,9 @@ class TableWriter[T] private (
 
   private val containsCollectionBehaviors =
     columnSelector.exists(_.isInstanceOf[CollectionColumnName])
+
+  private lazy val usesAutoTimestampForUpdate: Boolean =
+    !isCounterUpdate && writeConf.timestamp == TimestampOption.defaultValue
 
   private[connector] val isIdempotent: Boolean = {
     //All counter operations are not Idempotent
@@ -221,14 +226,18 @@ class TableWriter[T] private (
 
   def getAsyncWriter(): AsyncStatementWriter[T] = {
     if (isCounterUpdate || containsCollectionBehaviors) {
-      getAsyncWriterInternal(queryTemplateUsingUpdate)
+      getAsyncWriterInternal(
+        queryTemplateUsingUpdate,
+        autoTimestampParam = if (usesAutoTimestampForUpdate) Some(TableWriter.AutoTimestampParam) else None)
     }
     else {
       getAsyncWriterInternal(queryTemplateUsingInsert)
     }
   }
 
-  private def getAsyncWriterInternal(queryTemplate: String): AsyncStatementWriter[T] = {
+  private def getAsyncWriterInternal(
+      queryTemplate: String,
+      autoTimestampParam: Option[String] = None): AsyncStatementWriter[T] = {
     connector.withSessionDo { session =>
       val protocolVersion = session.getContext.getProtocolVersion
       val stmt = prepareStatement(queryTemplate, session)
@@ -238,7 +247,8 @@ class TableWriter[T] private (
         rowWriter,
         stmt,
         protocolVersion = protocolVersion,
-        ignoreNulls = writeConf.ignoreNulls)
+        ignoreNulls = writeConf.ignoreNulls,
+        autoTimestampParam = autoTimestampParam)
 
       val batchStmtBuilder = new BatchStatementBuilder(
         batchType,
@@ -341,7 +351,17 @@ case class AsyncStatementWriter[T](
 object TableWriter {
 
   /** Name of the auto-generated timestamp bind parameter added to UPDATE statements. */
-  private[writer] val AutoTimestampParam = "autots"
+  private[writer] val AutoTimestampParam = "connector_autots"
+
+  private[writer] def checkAutoTimestampCollisions(columnNames: Seq[String], writeConf: WriteConf): Unit = {
+    if (columnNames.contains(AutoTimestampParam))
+      throw new IllegalArgumentException(
+        s"Selected column '$AutoTimestampParam' conflicts with internal auto-timestamp parameter. " +
+        "Rename the column or use an explicit timestamp via WriteConf.")
+    if (writeConf.optionPlaceholders.contains(AutoTimestampParam))
+      throw new IllegalArgumentException(
+        s"Per-row placeholder name '$AutoTimestampParam' conflicts with internal auto-timestamp parameter.")
+  }
 
   private def checkMissingColumns(table: TableDef, columnNames: Seq[String]): Unit = {
     val allColumnNames = table.columns.map(_.columnName)

--- a/connector/src/test/scala/com/datastax/spark/connector/writer/TableWriterAutoTimestampTest.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/writer/TableWriterAutoTimestampTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.spark.connector.writer
+
+import org.junit.Test
+
+class TableWriterAutoTimestampTest {
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def shouldRejectSelectedColumnNamedLikeAutoTimestampParam(): Unit = {
+    TableWriter.checkAutoTimestampCollisions(Seq("pk", TableWriter.AutoTimestampParam), WriteConf())
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def shouldRejectWriteOptionPlaceholderNamedLikeAutoTimestampParam(): Unit = {
+    val writeConf = WriteConf(ttl = TTLOption.perRow(TableWriter.AutoTimestampParam))
+    TableWriter.checkAutoTimestampCollisions(Seq("pk", "value"), writeConf)
+  }
+}


### PR DESCRIPTION
Fixes #103.

This isolates the auto timestamp marker collision fix from the SPARKC-505 branch:
- auto-bind the connector timestamp marker only when TableWriter generated it;
- rename the internal marker to connector_autots;
- reject generated UPDATEs that would collide with selected user columns or per-row placeholders;
- cover both explicit auto timestamp binding and user-column preservation.

Validation:
- not rerun for this split branch; repo-ci fast currently fails before project tests because the learned command runs under Java 8 while the build uses -release:17.