### PR TITLE
fix: update concurrent writes doc default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ SHELL := bash
 
 MAKEFILE_PATH := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 SCYLLA_VERSION ?= LATEST
-GET_VERSION_VERSION := v0.4.3
-GET_VERSION_VERSION_NUM := 0.4.3
-GET_VERSION_CHECKSUM := 2dfbf1afd596fc9efd68c7795bfa52df0fd69d0342237574a17521b14f173df3
+GET_VERSION_VERSION := v0.4.5
+GET_VERSION_VERSION_NUM := 0.4.5
+GET_VERSION_CHECKSUM := 5a59cbf8c063c141c5904c21b5baebc708724a90b363b0804904f664a8485a84
 JAVA_OPENS?=-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED
 JAVA_VERSION_RAW:=$(shell java -version 2>&1 | head -n 1 | sed -E 's/.*"([0-9]+((\.|_)[0-9]+)*)".*/\1/')
 JAVA_MAJOR_VERSION:=$(word 1,$(subst ., ,$(JAVA_VERSION_RAW)))

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -413,7 +413,7 @@ in each row</td>
 </tr>
 <tr>
   <td><code>spark.cassandra.output.concurrent.writes</code></td>
-  <td>5</td>
+  <td>10</td>
   <td>Maximum number of batches executed in parallel by a
  single Spark task</td>
 </tr>


### PR DESCRIPTION
## Rationale
Integration CI failed in DocCheck because `doc/reference.md` still listed `spark.cassandra.output.concurrent.writes` as `5` while `WriteConf` defaults it to `10`.

A follow-up PR run then failed resolving `Cassandra 5-LATEST` because the pinned `get-version` helper did unauthenticated GitHub tag requests and hit API rate limits despite the workflow exporting `GITHUB_TOKEN`.

## Changes
- Updated the generated configuration reference default for `spark.cassandra.output.concurrent.writes` to `10`.
- Updated the CI `get-version` helper from `v0.4.3` to `v0.4.5`, which uses `GITHUB_TOKEN`/`GH_TOKEN` for GitHub tag resolution.

## Tests
- repo-ci fast: passed (workflow-build, workflow-lint, workflow-test, workflow-test-unit).
- repo-ci full: DocCheck passed; remaining local failures were CCM node startup failures across integration suites.
- GitHub CI on this PR: green, including Compile, Lint, Unit Tests, Test Coverage, CodeQL, and all integration matrix jobs.