### PR TITLE
cicd: fix release push after tag checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,10 @@ jobs:
           RELEASE_TARGET_TAG: ${{ inputs.target-tag }}
         run: make checkout-one-commit-before
 
+      - name: Checkout release branch
+        if: inputs.target-tag == 'scylla-4.x'
+        run: git switch -C scylla-4.x origin/scylla-4.x
+
       - name: Set up Java
         uses: actions/setup-java@v5
         with:
@@ -96,5 +100,5 @@ jobs:
       - name: Push changes to SCM
         if: ${{ inputs.dry-run == false && inputs.target-tag == 'scylla-4.x' }}
         run: |
-          git status && git log -3
-          git push origin --follow-tags -v
+          git status && git log -3 scylla-4.x
+          git push origin scylla-4.x --follow-tags -v


### PR DESCRIPTION
## Rationale
The Release workflow publishes from the release tag, which leaves Git in detached HEAD state. The final `git push origin --follow-tags` then fails because Git has no current branch to push.

## Changes
- Check out a real local `scylla-4.x` branch before running release preparation.
- Push `scylla-4.x` explicitly with `--follow-tags` after publishing, so the workflow can remain detached at the release tag while still pushing the prepared branch and annotated release tag.

## Tests
- Git-only simulation of the release path: prepared release commits, detached to the release tag, and confirmed `git push origin scylla-4.x --follow-tags` updates the branch and tag.
- repo-ci fast: passed (workflow-build, workflow-lint, workflow-test, workflow-test-unit).