### PR TITLE
SPARKC-110: Cache token-range scan statements by CQL

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Unreleased
+ * Cache token-range scan prepared statements by CQL template to avoid bind arity mismatches (#110)
  * Fix batched writes carrying consistency level on child statements,
    avoiding DefaultBatchStatement warnings (#98)
  * Avoid requiring ignored per-row write option placeholders for counter updates (#102)

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraScanPartitionReaderFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraScanPartitionReaderFactory.scala
@@ -122,21 +122,12 @@ abstract class CassandraPartitionReaderBase
   than all of the rows returned by the previous query have been consumed.
   */
   protected def getIterator(): Iterator[InternalRow] = {
-    // Prepare the scan statement once and reuse across all token ranges in this partition.
-    // The CQL template is identical for every range — only bind values differ.
-    // Must be lazy because `scanner` is initialized after `getIterator()` is called.
-    lazy val preparedStmt = tokenRanges.headOption.map { firstRange =>
-      val (cql, _) = ScanHelper.tokenRangeToCqlQuery(firstRange, tableDef, queryParts)
-      ScanHelper.prepareScanStatement(scanner.getSession(), cql)
-    }
+    // Min-token ranges can use a different token predicate and bind arity, so cache by exact CQL.
+    val preparedStatements = ScanHelper.newPreparedStatementCache()
 
     tokenRanges.iterator.flatMap { range =>
-      val scanResult = preparedStmt match {
-        case Some(ps) =>
-          ScanHelper.fetchTokenRange(scanner, tableDef, queryParts, range, readConf.consistencyLevel, readConf.fetchSizeInRows, ps)
-        case None =>
-          ScanHelper.fetchTokenRange(scanner, tableDef, queryParts, range, readConf.consistencyLevel, readConf.fetchSizeInRows)
-      }
+      val scanResult = ScanHelper.fetchTokenRange(
+        scanner, tableDef, queryParts, range, readConf.consistencyLevel, readConf.fetchSizeInRows, preparedStatements)
       val meta = scanResult.metadata
       scanResult.rows.map(rowReader.read(_, meta))
     }
@@ -188,4 +179,3 @@ case class CassandraCountPartitionReader(
     getIterator().flatMap(row => Iterator.fill(row.getLong(0).toInt)(InternalRow.empty))
   }
 }
-

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/ScanHelper.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/ScanHelper.scala
@@ -261,7 +261,15 @@ object ScanHelper extends Logging {
    * Bind values to an already-prepared statement.
    */
   def bindScanStatement(preparedStatement: PreparedStatement, values: Any*): BoundStatement = {
-    val variableDefinitions = preparedStatement.getVariableDefinitions.asScala.toIndexedSeq
+    def bindingException(t: Throwable) =
+      new IOException(s"Exception during binding of prepared statement: ${t.getMessage}", t)
+
+    val variableDefinitions = try {
+      preparedStatement.getVariableDefinitions.asScala.toIndexedSeq
+    }
+    catch {
+      case t: Throwable => throw bindingException(t)
+    }
     val expectedValues = variableDefinitions.size
     if (values.size != expectedValues) {
       throw new IOException(
@@ -280,7 +288,7 @@ object ScanHelper extends Logging {
     }
     catch {
       case t: Throwable =>
-        throw new IOException(s"Exception during binding of prepared statement: ${t.getMessage}", t)
+        throw bindingException(t)
     }
   }
 

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/ScanHelper.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/ScanHelper.scala
@@ -38,6 +38,11 @@ import scala.jdk.CollectionConverters._
 
 object ScanHelper extends Logging {
 
+  type PreparedStatementCache = scala.collection.mutable.Map[String, PreparedStatement]
+
+  def newPreparedStatementCache(): PreparedStatementCache =
+    scala.collection.mutable.Map.empty[String, PreparedStatement]
+
 
   def checkColumnsExistence(columns: Seq[ColumnRef], tableDef: TableDef): Seq[ColumnRef] = {
     val allColumnNames = tableDef.columns.map(_.columnName).toSet
@@ -90,6 +95,39 @@ object ScanHelper extends Logging {
         s"with params ${values.mkString("[", ",", "]")}")
 
     val stmt = prepareScanStatement(session, cql, values: _*)
+      .setConsistencyLevel(consistencyLevel)
+      .setPageSize(fetchSize)
+      .setRoutingToken(range.range.startNativeToken())
+
+    val scanResult = scanner.scan(stmt)
+    logDebug(s"Row iterator for range ${range.cql(partitionKeyStr(tableDef))} obtained successfully.")
+
+    scanResult
+  }
+
+  /**
+   * Variant of fetchTokenRange that reuses prepared statements by exact CQL template.
+   */
+  def fetchTokenRange(
+    scanner: Scanner,
+    tableDef: TableDef,
+    queryParts: CqlQueryParts,
+    range: CqlTokenRange[_, _],
+    consistencyLevel: ConsistencyLevel,
+    fetchSize: Int,
+    preparedStatements: PreparedStatementCache): ScanResult = {
+
+    val session = scanner.getSession()
+
+    val (cql, values) = tokenRangeToCqlQuery(range, tableDef, queryParts)
+
+    logDebug(
+      s"Fetching data for range ${range.cql(partitionKeyStr(tableDef))} " +
+        s"with $cql " +
+        s"with params ${values.mkString("[", ",", "]")}")
+
+    val preparedStatement = getOrPrepareScanStatement(session, cql, preparedStatements)
+    val stmt = bindScanStatement(preparedStatement, values: _*)
       .setConsistencyLevel(consistencyLevel)
       .setPageSize(fetchSize)
       .setRoutingToken(range.range.startNativeToken())
@@ -212,12 +250,26 @@ object ScanHelper extends Logging {
     }
   }
 
+  def getOrPrepareScanStatement(
+      session: CqlSession,
+      cql: String,
+      preparedStatements: PreparedStatementCache): PreparedStatement = {
+    preparedStatements.getOrElseUpdate(cql, prepareScanStatement(session, cql))
+  }
+
   /**
    * Bind values to an already-prepared statement.
    */
   def bindScanStatement(preparedStatement: PreparedStatement, values: Any*): BoundStatement = {
+    val variableDefinitions = preparedStatement.getVariableDefinitions.asScala.toIndexedSeq
+    val expectedValues = variableDefinitions.size
+    if (values.size != expectedValues) {
+      throw new IOException(
+        s"Cannot bind prepared scan statement: expected $expectedValues bind values, but got ${values.size}")
+    }
+
     try {
-      val converters = preparedStatement.getVariableDefinitions.asScala
+      val converters = variableDefinitions
         .map(v => ColumnType.converterToCassandra(v.getType))
         .toArray
       val convertedValues =

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
@@ -322,21 +322,13 @@ class CassandraTableScanRDD[R] private[connector](
     // Iterator flatMap trick flattens the iterator-of-iterator structure into a single iterator.
     // flatMap on iterator is lazy, therefore a query for the next token range is executed not earlier
     // than all of the rows returned by the previous query have been consumed
-    // Prepare the scan statement once and reuse across all token ranges in this partition.
-    // The CQL template is identical for every range — only bind values differ.
-    val preparedStmt = tokenRanges.headOption.map { firstRange =>
-      val (cql, _) = ScanHelper.tokenRangeToCqlQuery(firstRange, tableDef, queryParts)
-      ScanHelper.prepareScanStatement(scanner.getSession(), cql)
-    }
+    // Min-token ranges can use a different token predicate and bind arity, so cache by exact CQL.
+    val preparedStatements = ScanHelper.newPreparedStatementCache()
 
     val rowIterator = tokenRanges.iterator.flatMap { range =>
       try {
-        val scanResult = preparedStmt match {
-          case Some(ps) =>
-            ScanHelper.fetchTokenRange(scanner, tableDef, queryParts, range, consistencyLevel, fetchSize, ps)
-          case None =>
-            ScanHelper.fetchTokenRange(scanner, tableDef, queryParts, range, consistencyLevel, fetchSize)
-        }
+        val scanResult =
+          ScanHelper.fetchTokenRange(scanner, tableDef, queryParts, range, consistencyLevel, fetchSize, preparedStatements)
         val iteratorWithMetrics = scanResult.rows.map(metricsUpdater.updateMetrics)
         val result = iteratorWithMetrics.map(rowReader.read(_, scanResult.metadata))
         result

--- a/connector/src/test/scala/com/datastax/spark/connector/datasource/ScanHelperSpec.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/datasource/ScanHelperSpec.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.spark.connector.datasource
+
+import java.io.IOException
+import java.util.Arrays
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.cql.{ColumnDefinition, ColumnDefinitions, PreparedStatement}
+import com.datastax.oss.driver.api.core.`type`.DataTypes
+import com.datastax.spark.connector.SomeColumns
+import com.datastax.spark.connector.cql.{ColumnDef, PartitionKeyColumn, RegularColumn, TableDef}
+import com.datastax.spark.connector.datasource.ScanHelper.CqlQueryParts
+import com.datastax.spark.connector.rdd.CqlWhereClause
+import com.datastax.spark.connector.rdd.partitioner.CqlTokenRange
+import com.datastax.spark.connector.rdd.partitioner.dht.{LongToken, TokenFactory, TokenRange}
+import com.datastax.spark.connector.types.{IntType, TextType}
+import org.mockito.Mockito._
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
+
+class ScanHelperSpec extends FlatSpec with Matchers with MockitoSugar {
+
+  private implicit val tokenFactory: TokenFactory[Long, LongToken] = TokenFactory.Murmur3TokenFactory
+
+  private val tableDef = TableDef(
+    "test_ks",
+    "test_table",
+    Seq(ColumnDef("id", PartitionKeyColumn, IntType)),
+    Seq.empty,
+    Seq(ColumnDef("value", RegularColumn, TextType)))
+
+  private val queryParts = CqlQueryParts(
+    selectedColumnRefs = SomeColumns("id", "value").selectFrom(tableDef),
+    whereClause = CqlWhereClause.empty)
+
+  "ScanHelper" should "cache prepared statements by exact token range CQL template" in {
+    val (oneBindCql, oneBindValues) =
+      ScanHelper.tokenRangeToCqlQuery(tokenRange(tokenFactory.minToken, tokenFactory.minToken), tableDef, queryParts)
+    val (twoBindCql, twoBindValues) =
+      ScanHelper.tokenRangeToCqlQuery(tokenRange(LongToken(0L), LongToken(10L)), tableDef, queryParts)
+    val session = mock[CqlSession]
+    val oneBindStatement = mock[PreparedStatement]
+    val twoBindStatement = mock[PreparedStatement]
+    val cache = ScanHelper.newPreparedStatementCache()
+
+    oneBindValues should have size 1
+    twoBindValues should have size 2
+    oneBindCql should not equal twoBindCql
+    when(session.prepare(oneBindCql)).thenReturn(oneBindStatement)
+    when(session.prepare(twoBindCql)).thenReturn(twoBindStatement)
+
+    ScanHelper.getOrPrepareScanStatement(session, oneBindCql, cache) shouldBe oneBindStatement
+    ScanHelper.getOrPrepareScanStatement(session, twoBindCql, cache) shouldBe twoBindStatement
+    ScanHelper.getOrPrepareScanStatement(session, oneBindCql, cache) shouldBe oneBindStatement
+
+    verify(session, times(1)).prepare(oneBindCql)
+    verify(session, times(1)).prepare(twoBindCql)
+  }
+
+  it should "reject bind value count mismatches before binding" in {
+    val tooFew = intercept[IOException] {
+      ScanHelper.bindScanStatement(preparedStatementWithVariables(2), 1L)
+    }
+    val tooMany = intercept[IOException] {
+      ScanHelper.bindScanStatement(preparedStatementWithVariables(1), 1L, 2L)
+    }
+
+    tooFew.getMessage should include ("expected 2 bind values, but got 1")
+    tooMany.getMessage should include ("expected 1 bind values, but got 2")
+  }
+
+  private def tokenRange(start: LongToken, end: LongToken): CqlTokenRange[Long, LongToken] = {
+    CqlTokenRange(TokenRange(start, end, Set.empty, tokenFactory))
+  }
+
+  private def preparedStatementWithVariables(count: Int): PreparedStatement = {
+    val preparedStatement = mock[PreparedStatement]
+    val definitions = variableDefinitions(count)
+    when(preparedStatement.getVariableDefinitions).thenReturn(definitions)
+    preparedStatement
+  }
+
+  private def variableDefinitions(count: Int): ColumnDefinitions = {
+    val definitions = mock[ColumnDefinitions]
+    val columns = (1 to count).map { _ =>
+      val column = mock[ColumnDefinition]
+      when(column.getType).thenReturn(DataTypes.BIGINT)
+      column
+    }
+    when(definitions.iterator()).thenReturn(Arrays.asList(columns: _*).iterator())
+    definitions
+  }
+}

--- a/connector/src/test/scala/com/datastax/spark/connector/datasource/ScanHelperSpec.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/datasource/ScanHelperSpec.scala
@@ -21,16 +21,20 @@ package com.datastax.spark.connector.datasource
 import java.io.IOException
 import java.util.Arrays
 
-import com.datastax.oss.driver.api.core.CqlSession
-import com.datastax.oss.driver.api.core.cql.{ColumnDefinition, ColumnDefinitions, PreparedStatement}
+import com.datastax.oss.driver.api.core.{ConsistencyLevel, CqlSession}
+import com.datastax.oss.driver.api.core.cql.{BoundStatement, ColumnDefinition, ColumnDefinitions, PreparedStatement}
+import com.datastax.oss.driver.api.core.metadata.token.{Token => NativeToken}
 import com.datastax.oss.driver.api.core.`type`.DataTypes
-import com.datastax.spark.connector.SomeColumns
-import com.datastax.spark.connector.cql.{ColumnDef, PartitionKeyColumn, RegularColumn, TableDef}
+import com.datastax.spark.connector.{CassandraRowMetadata, SomeColumns}
+import com.datastax.spark.connector.cql.{CassandraConnectionFactory, CassandraConnector, CassandraConnectorConf}
+import com.datastax.spark.connector.cql.{ColumnDef, PartitionKeyColumn, RegularColumn, ScanResult, Scanner, TableDef}
 import com.datastax.spark.connector.datasource.ScanHelper.CqlQueryParts
-import com.datastax.spark.connector.rdd.CqlWhereClause
-import com.datastax.spark.connector.rdd.partitioner.CqlTokenRange
+import com.datastax.spark.connector.rdd.{CqlWhereClause, ReadConf}
+import com.datastax.spark.connector.rdd.partitioner.{CassandraPartition, CqlTokenRange}
 import com.datastax.spark.connector.rdd.partitioner.dht.{LongToken, TokenFactory, TokenRange}
 import com.datastax.spark.connector.types.{IntType, TextType}
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.mockito.ArgumentMatchers.{any => anyArg, anyInt}
 import org.mockito.Mockito._
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
@@ -49,6 +53,10 @@ class ScanHelperSpec extends FlatSpec with Matchers with MockitoSugar {
   private val queryParts = CqlQueryParts(
     selectedColumnRefs = SomeColumns("id", "value").selectFrom(tableDef),
     whereClause = CqlWhereClause.empty)
+
+  private val schema = StructType(Seq(
+    StructField("id", IntegerType, nullable = false),
+    StructField("value", StringType, nullable = true)))
 
   "ScanHelper" should "cache prepared statements by exact token range CQL template" in {
     val (oneBindCql, oneBindValues) =
@@ -74,6 +82,48 @@ class ScanHelperSpec extends FlatSpec with Matchers with MockitoSugar {
     verify(session, times(1)).prepare(twoBindCql)
   }
 
+  it should "scan mixed token range CQL templates through the partition reader cache" in {
+    val oneBindRange = tokenRange(tokenFactory.minToken, tokenFactory.minToken)
+    val twoBindRange = tokenRange(LongToken(0L), LongToken(10L))
+    val (oneBindCql, _) = ScanHelper.tokenRangeToCqlQuery(oneBindRange, tableDef, queryParts)
+    val (twoBindCql, _) = ScanHelper.tokenRangeToCqlQuery(twoBindRange, tableDef, queryParts)
+    val connector = mock[CassandraConnector]
+    val connectionFactory = mock[CassandraConnectionFactory]
+    val connectorConf = mock[CassandraConnectorConf]
+    val scanner = mock[Scanner]
+    val session = mock[CqlSession]
+    val metadata = CassandraRowMetadata(IndexedSeq("id", "value"))
+    val oneBindBoundStatement = boundStatement()
+    val twoBindBoundStatement = boundStatement()
+    val oneBindStatement = preparedStatementWithVariables(1, oneBindBoundStatement)
+    val twoBindStatement = preparedStatementWithVariables(2, twoBindBoundStatement)
+    val readConf = ReadConf()
+    val partition = CassandraPartition(0, Array.empty[String], Seq(oneBindRange, twoBindRange), 0L)
+    val readerFactory = CassandraScanPartitionReaderFactory(connector, tableDef, schema, readConf, queryParts)
+
+    when(connector.connectionFactory).thenReturn(connectionFactory)
+    when(connector.conf).thenReturn(connectorConf)
+    when(connectionFactory.getScanner(readConf, connectorConf, IndexedSeq("id", "value")))
+      .thenReturn(scanner)
+    when(scanner.getSession()).thenReturn(session)
+    when(session.prepare(oneBindCql)).thenReturn(oneBindStatement)
+    when(session.prepare(twoBindCql)).thenReturn(twoBindStatement)
+    when(scanner.scan(oneBindBoundStatement)).thenReturn(ScanResult(Iterator.empty, metadata))
+    when(scanner.scan(twoBindBoundStatement)).thenReturn(ScanResult(Iterator.empty, metadata))
+
+    val reader = readerFactory.createReader(partition)
+
+    reader.next() shouldBe false
+
+    verify(session, times(1)).prepare(oneBindCql)
+    verify(session, times(1)).prepare(twoBindCql)
+    verify(oneBindStatement, times(1)).bind(anyArg[Object]())
+    verify(twoBindStatement, times(1)).bind(anyArg[Object](), anyArg[Object]())
+    verify(scanner, times(1)).scan(oneBindBoundStatement)
+    verify(scanner, times(1)).scan(twoBindBoundStatement)
+    reader.close()
+  }
+
   it should "reject bind value count mismatches before binding" in {
     val tooFew = intercept[IOException] {
       ScanHelper.bindScanStatement(preparedStatementWithVariables(2), 1L)
@@ -86,15 +136,46 @@ class ScanHelperSpec extends FlatSpec with Matchers with MockitoSugar {
     tooMany.getMessage should include ("expected 1 bind values, but got 2")
   }
 
+  it should "wrap variable metadata failures while binding prepared scan statements" in {
+    val preparedStatement = mock[PreparedStatement]
+    val failure = new IllegalStateException("variable metadata unavailable")
+    when(preparedStatement.getVariableDefinitions).thenThrow(failure)
+
+    val thrown = intercept[IOException] {
+      ScanHelper.bindScanStatement(preparedStatement, 1L)
+    }
+
+    thrown.getMessage should include ("Exception during binding of prepared statement")
+    thrown.getCause shouldBe failure
+  }
+
   private def tokenRange(start: LongToken, end: LongToken): CqlTokenRange[Long, LongToken] = {
     CqlTokenRange(TokenRange(start, end, Set.empty, tokenFactory))
   }
 
-  private def preparedStatementWithVariables(count: Int): PreparedStatement = {
+  private def preparedStatementWithVariables(count: Int): PreparedStatement =
+    preparedStatementWithVariables(count, boundStatement())
+
+  private def preparedStatementWithVariables(count: Int, boundStatement: BoundStatement): PreparedStatement = {
     val preparedStatement = mock[PreparedStatement]
     val definitions = variableDefinitions(count)
     when(preparedStatement.getVariableDefinitions).thenReturn(definitions)
+    count match {
+      case 0 => when(preparedStatement.bind()).thenReturn(boundStatement)
+      case 1 => when(preparedStatement.bind(anyArg[Object]())).thenReturn(boundStatement)
+      case 2 => when(preparedStatement.bind(anyArg[Object](), anyArg[Object]())).thenReturn(boundStatement)
+      case _ => throw new IllegalArgumentException(s"Unsupported test variable count: $count")
+    }
     preparedStatement
+  }
+
+  private def boundStatement(): BoundStatement = {
+    val statement = mock[BoundStatement]
+    when(statement.setIdempotent(true)).thenReturn(statement)
+    when(statement.setConsistencyLevel(anyArg[ConsistencyLevel]())).thenReturn(statement)
+    when(statement.setPageSize(anyInt())).thenReturn(statement)
+    when(statement.setRoutingToken(anyArg[NativeToken]())).thenReturn(statement)
+    statement
   }
 
   private def variableDefinitions(count: Int): ColumnDefinitions = {
@@ -104,7 +185,7 @@ class ScanHelperSpec extends FlatSpec with Matchers with MockitoSugar {
       when(column.getType).thenReturn(DataTypes.BIGINT)
       column
     }
-    when(definitions.iterator()).thenReturn(Arrays.asList(columns: _*).iterator())
+    when(definitions.iterator()).thenAnswer(_ => Arrays.asList(columns: _*).iterator())
     definitions
   }
 }


### PR DESCRIPTION
Fixes #110

## Rationale
Token-range scans can generate different CQL templates within the same Spark partition when a range touches the minimum token. Reusing the statement prepared from the first range can leave bind markers unset or drop bind values for later ranges.

## Changes
- Cache prepared scan statements per exact CQL template for RDD and DataSource V2 token-range scans.
- Add bind arity validation in ScanHelper before binding prepared statements.
- Add unit coverage for CQL-keyed prepared statement reuse and bind-count mismatch failures.

## Tests
- repo-ci fast: lint passed; test-unit is blocked locally because the repo-ci runner invokes sbt with Java 8 while the build uses -release:17.
- env JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH ./sbt/sbt "connector/Test/testOnly com.datastax.spark.connector.datasource.ScanHelperSpec": passed.
