### PR TITLE
GH-98: Restore write attributes on final statements

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/writer/QueryExecutor.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/QueryExecutor.scala
@@ -18,26 +18,53 @@
 
 package com.datastax.spark.connector.writer
 
+import com.datastax.oss.driver.api.core.ConsistencyLevel
 import com.datastax.oss.driver.api.core.CqlSession
-import com.datastax.oss.driver.api.core.cql.AsyncResultSet
+import com.datastax.oss.driver.api.core.cql.{AsyncResultSet, Statement}
 import com.datastax.spark.connector.cql.CassandraConnectorConf
 import com.datastax.spark.connector.writer.AsyncExecutor.Handler
 
 class QueryExecutor(
- session: CqlSession,
- maxConcurrentQueries: Int,
- successHandler: Option[Handler[RichStatement]],
- failureHandler: Option[Handler[RichStatement]],
- maxRetries: Int = CassandraConnectorConf.QueryRetryMaxRetriesParam.default)
+    session: CqlSession,
+    maxConcurrentQueries: Int,
+    successHandler: Option[Handler[RichStatement]],
+    failureHandler: Option[Handler[RichStatement]],
+    maxRetries: Int,
+    consistencyLevel: Option[ConsistencyLevel],
+    isIdempotent: Option[Boolean])
 
   extends AsyncExecutor[RichStatement, AsyncResultSet](
-    stmt => session.executeAsync(stmt.stmt),
+    stmt => session.executeAsync(QueryExecutor.applyWriteAttributes(stmt.stmt, consistencyLevel, isIdempotent)),
     maxConcurrentQueries,
     successHandler,
     failureHandler,
-    maxRetries)
+    maxRetries) {
+
+  // Preserve the legacy JVM constructor signature for compiled callers.
+  def this(
+      session: CqlSession,
+      maxConcurrentQueries: Int,
+      successHandler: Option[Handler[RichStatement]],
+      failureHandler: Option[Handler[RichStatement]],
+      maxRetries: Int) =
+    this(session, maxConcurrentQueries, successHandler, failureHandler, maxRetries, None, None)
+}
 
 object QueryExecutor {
+
+  private[writer] def applyWriteAttributes(
+      stmt: Statement[_ <: Statement[_]],
+      consistencyLevel: Option[ConsistencyLevel],
+      isIdempotent: Option[Boolean]): Statement[_ <: Statement[_]] = {
+    val withConsistency = consistencyLevel match {
+      case Some(level) => stmt.setConsistencyLevel(level)
+      case None => stmt
+    }
+    isIdempotent match {
+      case Some(flag) => withConsistency.setIdempotent(flag)
+      case None => withConsistency
+    }
+  }
 
   def apply(
     session: CqlSession,
@@ -45,7 +72,12 @@ object QueryExecutor {
     successHandler: Option[Handler[RichStatement]],
     failureHandler: Option[Handler[RichStatement]]): QueryExecutor = {
 
-    new QueryExecutor(session, maxConcurrentQueries, successHandler, failureHandler)
+    new QueryExecutor(
+      session,
+      maxConcurrentQueries,
+      successHandler,
+      failureHandler,
+      CassandraConnectorConf.QueryRetryMaxRetriesParam.default)
   }
 
   def apply(

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -279,13 +279,9 @@ class TableWriter[T] private (
 
   private def prepareStatement(
       queryTemplate:String,
-      session: CqlSession,
-      idempotent: Boolean): PreparedStatement = {
+      session: CqlSession): PreparedStatement = {
     try {
-      val stmt = SimpleStatement.newInstance(queryTemplate)
-        .setIdempotent(idempotent)
-        .setConsistencyLevel(writeConf.consistencyLevel)
-      session.prepare(stmt)
+      session.prepare(SimpleStatement.newInstance(queryTemplate))
     }
     catch {
       case t: Throwable =>
@@ -363,8 +359,7 @@ class TableWriter[T] private (
       val protocolVersion = session.getContext.getProtocolVersion
       val deleteStatement = isDelete || isDeleteStatement
       val statementIdempotent = if (deleteStatement) true else isIdempotent
-      val stmt = prepareStatement(queryTemplate, session,
-        idempotent = statementIdempotent)
+      val stmt = prepareStatement(queryTemplate, session)
       val batchType = if (isCounterUpdate) DefaultBatchType.COUNTER else DefaultBatchType.UNLOGGED
 
       val boundStmtBuilder = new BoundStatementBuilder(
@@ -392,7 +387,8 @@ class TableWriter[T] private (
           (stmt: RichStatement) => ()
       }
 
-      AsyncStatementWriter(connector, writeConf, tableDef, stmt, batchBuilder, maybeRateLimit)
+      AsyncStatementWriter(connector, writeConf, tableDef, stmt, batchBuilder, maybeRateLimit,
+        statementIdempotent = statementIdempotent)
     }
   }
 
@@ -430,6 +426,7 @@ case class AsyncStatementWriter[T](
   preparedStatement: PreparedStatement,
   groupingBatchBuilderBase: GroupingBatchBuilderBase[T],
   maybeRateLimit: RichStatement => Unit,
+  statementIdempotent: Boolean = false,
   successHandler: Option[Handler[RichStatement]] = None,
   failureHandler: Option[Handler[RichStatement]] = None)
   extends Closeable
@@ -442,7 +439,9 @@ case class AsyncStatementWriter[T](
 
   private lazy val queryExecutor = new QueryExecutor(
     session, writeConf.parallelismLevel, successHandler, failureHandler,
-    maxRetries = connector.conf.queryRetryMaxRetries)
+    maxRetries = connector.conf.queryRetryMaxRetries,
+    consistencyLevel = Some(writeConf.consistencyLevel),
+    isIdempotent = Some(statementIdempotent))
 
   def write(record: T): Unit= {
     groupingBatchBuilderBase.batchRecord(record).foreach{ stmt =>

--- a/connector/src/test/scala/com/datastax/spark/connector/writer/QueryExecutorTest.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/writer/QueryExecutorTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.spark.connector.writer
+
+import java.util.concurrent.CompletableFuture
+
+import com.datastax.oss.driver.api.core.DefaultConsistencyLevel
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.cql.{AsyncResultSet, BoundStatement}
+import com.datastax.spark.connector.cql.CassandraConnectorConf
+import org.junit.Test
+import org.junit.Assert._
+import org.mockito.Mockito._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class QueryExecutorTest {
+
+  @Test
+  def queryExecutorShouldKeepLegacyConstructorSignature(): Unit = {
+    val legacySignature = Seq(
+      classOf[CqlSession],
+      Integer.TYPE,
+      classOf[Option[_]],
+      classOf[Option[_]],
+      Integer.TYPE).map(_.getName)
+
+    val hasLegacySignature = classOf[QueryExecutor].getConstructors.exists { ctor =>
+      ctor.getParameterTypes.map(_.getName).toSeq == legacySignature
+    }
+
+    assertTrue("QueryExecutor must keep the legacy 5-argument constructor for binary compatibility",
+      hasLegacySignature)
+  }
+
+  @Test
+  def executeAsyncShouldApplyWriteAttributesAtExecutionTime(): Unit = {
+    val session = mock(classOf[CqlSession])
+    val initialStatement = mock(classOf[BoundStatement])
+    val idempotentStatement = mock(classOf[BoundStatement])
+    val consistentStatement = mock(classOf[BoundStatement])
+    val resultSet = mock(classOf[AsyncResultSet])
+
+    when(initialStatement.setConsistencyLevel(DefaultConsistencyLevel.THREE))
+      .thenReturn(idempotentStatement)
+    when(idempotentStatement.setIdempotent(true))
+      .thenReturn(consistentStatement)
+    when(session.executeAsync(consistentStatement))
+      .thenReturn(CompletableFuture.completedFuture(resultSet))
+
+    val executor = new QueryExecutor(
+      session,
+      1,
+      None,
+      None,
+      CassandraConnectorConf.QueryRetryMaxRetriesParam.default,
+      Some(DefaultConsistencyLevel.THREE),
+      Some(true))
+
+    val future = executor.executeAsync(new RichBoundStatementWrapper(initialStatement))
+    Await.result(future, 5.seconds)
+
+    verify(initialStatement).setConsistencyLevel(DefaultConsistencyLevel.THREE)
+    verify(idempotentStatement).setIdempotent(true)
+    verify(session).executeAsync(consistentStatement)
+    assertTrue(future.isCompleted)
+  }
+}

--- a/connector/src/test/scala/com/datastax/spark/connector/writer/TableWriterRegressionTest.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/writer/TableWriterRegressionTest.scala
@@ -35,6 +35,7 @@ import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.types.{CounterType, IntType, ListType, SetType, TextType, UUIDType}
 import org.apache.spark.TaskContext
 import org.junit.{Assert, Test}
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 
@@ -175,6 +176,47 @@ class TableWriterRegressionTest {
         Assert.assertTrue(e.getMessage.contains("INSERT"))
         Assert.assertTrue(e.getMessage.contains("ttl_col"))
     }
+  }
+
+  @Test
+  def preparedWriteStatementShouldNotCarryWriteAttributes(): Unit = {
+    val preparedStatement = preparedStatementWithVariables(
+      "pk" -> ProtocolConstants.DataType.INT,
+      "ck" -> ProtocolConstants.DataType.INT,
+      "value" -> ProtocolConstants.DataType.VARCHAR)
+    val session = mock(classOf[CqlSession])
+    val context = mock(classOf[DriverContext])
+    when(context.getProtocolVersion).thenReturn(ProtocolVersion.DEFAULT)
+    when(session.getContext).thenReturn(context)
+    when(session.prepare(any(classOf[SimpleStatement]))).thenReturn(preparedStatement)
+
+    val connector = new CassandraConnector(createConnector().conf) {
+      override def openSession(): CqlSession = session
+      override def withSessionDo[T](code: CqlSession => T): T = code(session)
+    }
+
+    val writer = TableWriter[CassandraRow](
+      connector,
+      createTableDef(),
+      AllColumns,
+      WriteConf(
+        batchGroupingKey = BatchGroupingKey.None,
+        consistencyLevel = com.datastax.oss.driver.api.core.DefaultConsistencyLevel.THREE),
+      partitionKeyOnly = false,
+      partitions = Array.empty,
+      tokenRangeAcc = None,
+      isDelete = false)
+
+    writer.getAsyncWriter()
+
+    val stmtCaptor = ArgumentCaptor.forClass(classOf[SimpleStatement])
+    verify(session).prepare(stmtCaptor.capture())
+    val preparedTemplate = stmtCaptor.getValue
+
+    Assert.assertNull("Prepared template should not carry a consistency level",
+      preparedTemplate.getConsistencyLevel)
+    Assert.assertNull("Prepared template should not be marked idempotent",
+      preparedTemplate.isIdempotent)
   }
 
   @Test


### PR DESCRIPTION
Restores the GH-98 behavior that keeps write consistency and idempotence off the prepared SimpleStatement so bound child statements do not inherit ignored metadata and trigger DefaultBatchStatement warnings.

The regression came back in PR #96 (SPARKC-505: Add WriteConf support to delete and update query templates), which reintroduced write attributes on the prepared template. This change removes that stamping again, and applies write consistency and idempotence at execution time in QueryExecutor so the final statement sent to the session still carries the configured write attributes.

Tests:
- connector/testOnly com.datastax.spark.connector.writer.QueryExecutorTest
- connector/testOnly com.datastax.spark.connector.writer.TableWriterRegressionTest
- connector/testOnly com.datastax.spark.connector.writer.BatchStatementBuilderTest
