### PR TITLE
ci: Create GitHub release from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,3 +99,20 @@ jobs:
         run: |
           git status && git log -3 scylla-4.x
           git push origin scylla-4.x --follow-tags -v
+
+      - name: Create GitHub release
+        if: inputs.dry-run == false
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RELEASE_TAG=$(git describe --tags --abbrev=0 --match 'v*')
+
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "GitHub release ${RELEASE_TAG} already exists"
+            exit 0
+          fi
+
+          gh release create "${RELEASE_TAG}" \
+            --title "${RELEASE_TAG}" \
+            --generate-notes \
+            --verify-tag


### PR DESCRIPTION
## Rationale
Create a GitHub release automatically at the end of a successful non-dry-run release workflow. The new step runs after SCM push so the release tag is present on GitHub before `gh release create --verify-tag` runs.

## Changes
- Add a final `Create GitHub release` step to `.github/workflows/release.yml`.
- Use the workflow `github.token` with `contents: write` permissions.
- Skip creation when the GitHub release already exists, keeping reruns and tagged re-releases idempotent.
- Generate GitHub release notes automatically from the tag.

## Tests
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "YAML OK"'`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`\n\n## Caveats\n- JIRA issue was not provided for this automation-only change.