### PR TITLE
Issue #117: add connector-level read retries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
 Unreleased
+ * Add configurable connector-level read request retries for idempotent scans (#117)
+ * Mark connector-generated read and metadata SELECT statements idempotent (#117)
  * Cache token-range scan prepared statements by CQL template to avoid bind arity mismatches (#110)
  * Fix batched writes carrying consistency level on child statements,
    avoiding DefaultBatchStatement warnings (#98)

--- a/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -243,6 +243,7 @@ object CassandraConnectorConf extends Logging {
     description =
       """Number of times to retry a timed-out query
         |Setting this to -1 means unlimited retries
+        |This configures the Java driver retry policy, not connector-level read request retry.
       """.stripMargin)
 
   val QueryRetryMaxRetriesParam = ConfigParameter[Int](

--- a/connector/src/main/scala/com/datastax/spark/connector/cql/Scanner.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/Scanner.scala
@@ -23,7 +23,7 @@ import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.{Row, Statement}
 import com.datastax.spark.connector.CassandraRowMetadata
 import com.datastax.spark.connector.rdd.ReadConf
-import com.datastax.spark.connector.rdd.reader.PrefetchingResultSetIterator
+import com.datastax.spark.connector.rdd.reader.{ConnectorReadRequestRetrier, PrefetchingResultSetIterator}
 import com.datastax.spark.connector.util.maybeExecutingAs
 import com.datastax.spark.connector.writer.RateLimiter
 
@@ -59,10 +59,14 @@ class DefaultScanner (
   override def scan[StatementT <: Statement[StatementT]](statement: StatementT): ScanResult = {
     import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
 
-    val rs = session.executeAsync(maybeExecutingAs(statement, readConf.executeAs))
+    val statementToExecute = maybeExecutingAs(statement, readConf.executeAs)
+    val retrier = new ConnectorReadRequestRetrier(readConf.connectorRetry)
+    val rs = retrier.executeAsync(statementToExecute, "first-page") {
+      session.executeAsync(statementToExecute)
+    }
     val scanResult = asScalaFuture(rs).map { rs =>
       val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs, codecRegistry)
-      val prefetchingIterator = new PrefetchingResultSetIterator(rs)
+      val prefetchingIterator = new PrefetchingResultSetIterator(rs, None, readConf.connectorRetry)
       val rateLimitingIterator = readConf.throughputMiBPS match {
         case Some(throughput) =>
           val rateLimiter = new RateLimiter((throughput * 1024 * 1024).toLong, 1024 * 1024)

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraInJoinReaderFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraInJoinReaderFactory.scala
@@ -20,10 +20,10 @@ package com.datastax.spark.connector.datasource
 
 import com.datastax.spark.connector.cql.{CassandraConnector, TableDef}
 import com.datastax.spark.connector.rdd.ReadConf
-import com.datastax.spark.connector.rdd.reader.PrefetchingResultSetIterator
+import com.datastax.spark.connector.rdd.reader.{ConnectorReadQueryExecutor, PrefetchingResultSetIterator}
 import com.datastax.spark.connector.util.Logging
 import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
-import com.datastax.spark.connector.writer.{CassandraRowWriter, QueryExecutor}
+import com.datastax.spark.connector.writer.CassandraRowWriter
 import com.datastax.spark.connector.{CassandraRow, CassandraRowMetadata, ColumnName, RowCountRef}
 import com.google.common.util.concurrent.SettableFuture
 import org.apache.spark.sql.catalyst.InternalRow
@@ -79,7 +79,7 @@ abstract class CassandraBaseInJoinReader(
   protected val bsb = JoinHelper.getKeyBuilderStatementBuilder(session, rowWriter, preparedStatement, cqlQueryParts.whereClause)
   protected val rowMetadata = JoinHelper.getCassandraRowMetadata(session, preparedStatement, cqlQueryParts.selectedColumnRefs)
 
-  protected val queryExecutor = QueryExecutor(session, readConf.parallelismLevel, None, None, connector.conf)
+  protected val queryExecutor = ConnectorReadQueryExecutor(session, readConf, connector.conf)
   protected val maybeRateLimit = JoinHelper.maybeRateLimit(readConf)
   protected val requestsPerSecondRateLimiter = JoinHelper.requestsPerSecondRateLimiter(readConf)
 
@@ -87,9 +87,9 @@ abstract class CassandraBaseInJoinReader(
     val resultFuture = SettableFuture.create[Iterator[(CassandraRow, InternalRow)]]
     val leftSide = Iterator.continually(left)
 
-    queryExecutor.executeAsync(bsb.bind(left).executeAs(readConf.executeAs)).onComplete {
+    queryExecutor.executeAsync(bsb.bind(left).setIdempotent(true).executeAs(readConf.executeAs)).onComplete {
       case Success(rs) =>
-        val resultSet = new PrefetchingResultSetIterator(rs)
+        val resultSet = new PrefetchingResultSetIterator(rs, None, readConf.connectorRetry)
         /* This is a much less than ideal place to actually rate limit, we are buffering
         these futures this means we will most likely exceed our threshold*/
         val throttledIterator = resultSet.map(maybeRateLimit)

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/JoinHelper.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/JoinHelper.scala
@@ -289,7 +289,7 @@ object JoinHelper extends Logging {
       rowWriter.readColumnValues(elem, buffer)
       bindValue(buffer(lastCkIndex))
     }
-    boundStmt
+    boundStmt.setIdempotent(true)
   }
 
   /** Compare two CK values that might have different runtime types (e.g. Int vs Long). */

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraCoGroupedRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraCoGroupedRDD.scala
@@ -37,7 +37,7 @@ import com.datastax.spark.connector.CassandraRowMetadata
 import com.datastax.spark.connector.cql.{CassandraConnector, ColumnDef, Schema}
 import com.datastax.spark.connector.rdd.CassandraCoGroupedRDD._
 import com.datastax.spark.connector.rdd.partitioner.{CassandraPartition, CqlTokenRange, NodeAddresses}
-import com.datastax.spark.connector.rdd.reader.{PrefetchingResultSetIterator, RowReader}
+import com.datastax.spark.connector.rdd.reader.{ConnectorReadRequestRetrier, PrefetchingResultSetIterator, RowReader}
 import com.datastax.spark.connector.types.ColumnType
 import com.datastax.spark.connector.util.Quote._
 import com.datastax.spark.connector.util.{CountingIterator, MultiMergeJoinIterator, NameTools}
@@ -178,10 +178,13 @@ class CassandraCoGroupedRDD[T](
 
     import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
 
-    val fetchResult = asScalaFuture(session.executeAsync(stmt)).map { rs =>
+    val retrier = new ConnectorReadRequestRetrier(fromRDD.readConf.connectorRetry)
+    val fetchResult = asScalaFuture(retrier.executeAsync(stmt, "first-page") {
+      session.executeAsync(stmt)
+    }).map { rs =>
       val columnNames = fromRDD.selectedColumnRefs.map(_.selectedAs).toIndexedSeq ++ Seq(TokenColumn)
       val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs, session.getContext.getCodecRegistry)
-      val iterator = new PrefetchingResultSetIterator(rs)
+      val iterator = new PrefetchingResultSetIterator(rs, None, fromRDD.readConf.connectorRetry)
       val iteratorWithMetrics = iterator.map(inputMetricsUpdater.updateMetrics)
       logDebug(s"Row iterator for range $range obtained successfully.")
       (columnMetaData, iteratorWithMetrics)

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -170,7 +170,7 @@ class CassandraJoinRDD[L, R] (
     metricsUpdater: InputMetricsUpdater
   ): Iterator[(L, R)] = {
 
-    val queryExecutor = QueryExecutor(session, readConf.parallelismLevel, None, None, connector.conf)
+    val queryExecutor = ConnectorReadQueryExecutor(session, readConf, connector.conf)
 
     def pairWithRight(left: L): SettableFuture[Iterator[(L, R)]] = {
       val resultFuture = SettableFuture.create[Iterator[(L, R)]]
@@ -180,10 +180,11 @@ class CassandraJoinRDD[L, R] (
 
       val stmt = bsb.bind(left)
         .update(_.setPageSize(readConf.fetchSizeInRows))
+        .setIdempotent(true)
         .executeAs(readConf.executeAs)
       queryExecutor.executeAsync(stmt).onComplete {
         case Success(rs) =>
-          val resultSet = new PrefetchingResultSetIterator(rs)
+          val resultSet = new PrefetchingResultSetIterator(rs, None, readConf.connectorRetry)
           val iteratorWithMetrics = resultSet.map(metricsUpdater.updateMetrics)
           val throttledIterator = iteratorWithMetrics.map(JoinHelper.maybeRateLimit(readConf))
           val rightSide = throttledIterator.map(rowReader.read(_, rowMetadata))
@@ -217,16 +218,19 @@ class CassandraJoinRDD[L, R] (
 
     import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
 
-    val queryExecutor = QueryExecutor(session, readConf.parallelismLevel, None, None, connector.conf)
+    val queryExecutor = ConnectorReadQueryExecutor(session, readConf, connector.conf)
     val codecRegistry = session.getContext.getCodecRegistry
     val ctx = InClauseContext(session)
 
     def pairSingleWithRight(left: L): SettableFuture[Iterator[(L, R)]] = {
       val resultFuture = SettableFuture.create[Iterator[(L, R)]]
-      val stmt = bsb.bind(left).update(_.setPageSize(readConf.fetchSizeInRows)).executeAs(readConf.executeAs)
+      val stmt = bsb.bind(left)
+        .update(_.setPageSize(readConf.fetchSizeInRows))
+        .setIdempotent(true)
+        .executeAs(readConf.executeAs)
       queryExecutor.executeAsync(stmt).onComplete {
         case Success(rs) =>
-          val it = new PrefetchingResultSetIterator(rs).map(metricsUpdater.updateMetrics)
+          val it = new PrefetchingResultSetIterator(rs, None, readConf.connectorRetry).map(metricsUpdater.updateMetrics)
           val throttled = it.map(JoinHelper.maybeRateLimit(readConf))
           resultFuture.set(Iterator.continually(left).zip(throttled.map(rowReader.read(_, rowMetadata))))
         case Failure(t) => resultFuture.setException(t)
@@ -246,7 +250,7 @@ class CassandraJoinRDD[L, R] (
       val richStmt = new RichBoundStatementWrapper(boundStmt).executeAs(readConf.executeAs)
       queryExecutor.executeAsync(richStmt).onComplete {
         case Success(rs) =>
-          val it = new PrefetchingResultSetIterator(rs).map(metricsUpdater.updateMetrics)
+          val it = new PrefetchingResultSetIterator(rs, None, readConf.connectorRetry).map(metricsUpdater.updateMetrics)
           val throttled = it.map(JoinHelper.maybeRateLimit(readConf))
           resultFuture.set(ctx.matchResultsToLefts(throttled, ckValueToLefts, rowMetadata, rowReader))
         case Failure(t) => resultFuture.setException(t)

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -178,7 +178,7 @@ class CassandraLeftJoinRDD[L, R] (
   ): Iterator[(L, Option[R])] = {
     import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
 
-    val queryExecutor = QueryExecutor(session, readConf.parallelismLevel, None, None, connector.conf)
+    val queryExecutor = ConnectorReadQueryExecutor(session, readConf, connector.conf)
 
     def pairWithRight(left: L): SettableFuture[Iterator[(L, Option[R])]] = {
       val resultFuture = SettableFuture.create[Iterator[(L, Option[R])]]
@@ -186,10 +186,11 @@ class CassandraLeftJoinRDD[L, R] (
 
       val stmt = bsb.bind(left)
         .update(_.setPageSize(readConf.fetchSizeInRows))
+        .setIdempotent(true)
         .executeAs(readConf.executeAs)
       queryExecutor.executeAsync(stmt).onComplete {
         case Success(rs) =>
-          val resultSet = new PrefetchingResultSetIterator(rs)
+          val resultSet = new PrefetchingResultSetIterator(rs, None, readConf.connectorRetry)
           val iteratorWithMetrics = resultSet.map(metricsUpdater.updateMetrics)
           val throttledIterator = iteratorWithMetrics.map(maybeRateLimit)
           val rightSide = resultSet.isEmpty match {
@@ -226,16 +227,19 @@ class CassandraLeftJoinRDD[L, R] (
 
     import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
 
-    val queryExecutor = QueryExecutor(session, readConf.parallelismLevel, None, None, connector.conf)
+    val queryExecutor = ConnectorReadQueryExecutor(session, readConf, connector.conf)
     val codecRegistry = session.getContext.getCodecRegistry
     val ctx = InClauseContext(session)
 
     def pairSingleWithRight(left: L): SettableFuture[Iterator[(L, Option[R])]] = {
       val resultFuture = SettableFuture.create[Iterator[(L, Option[R])]]
-      val stmt = bsb.bind(left).update(_.setPageSize(readConf.fetchSizeInRows)).executeAs(readConf.executeAs)
+      val stmt = bsb.bind(left)
+        .update(_.setPageSize(readConf.fetchSizeInRows))
+        .setIdempotent(true)
+        .executeAs(readConf.executeAs)
       queryExecutor.executeAsync(stmt).onComplete {
         case Success(rs) =>
-          val resultSet = new PrefetchingResultSetIterator(rs)
+          val resultSet = new PrefetchingResultSetIterator(rs, None, readConf.connectorRetry)
           val it = resultSet.map(metricsUpdater.updateMetrics).map(maybeRateLimit)
           val rightSide = if (resultSet.isEmpty) Iterator.single(None)
             else it.map(r => Some(rowReader.read(r, rowMetadata)))
@@ -257,7 +261,7 @@ class CassandraLeftJoinRDD[L, R] (
       val richStmt = new RichBoundStatementWrapper(boundStmt).executeAs(readConf.executeAs)
       queryExecutor.executeAsync(richStmt).onComplete {
         case Success(rs) =>
-          val it = new PrefetchingResultSetIterator(rs).map(metricsUpdater.updateMetrics)
+          val it = new PrefetchingResultSetIterator(rs, None, readConf.connectorRetry).map(metricsUpdater.updateMetrics)
           val throttled = it.map(maybeRateLimit)
           resultFuture.set(ctx.matchLeftJoinResults(throttled, group, ckValueToLefts, rowMetadata, rowReader))
         case Failure(t) => resultFuture.setException(t)

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraMergeJoinRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraMergeJoinRDD.scala
@@ -35,7 +35,7 @@ import com.datastax.oss.driver.api.core.metadata.token.Token
 import com.datastax.spark.connector.CassandraRowMetadata
 import com.datastax.spark.connector.cql.{CassandraConnector, ColumnDef}
 import com.datastax.spark.connector.rdd.partitioner.{CassandraPartition, CqlTokenRange, NodeAddresses}
-import com.datastax.spark.connector.rdd.reader.{PrefetchingResultSetIterator, RowReader}
+import com.datastax.spark.connector.rdd.reader.{ConnectorReadRequestRetrier, PrefetchingResultSetIterator, RowReader}
 import com.datastax.spark.connector.types.ColumnType
 import com.datastax.spark.connector.util.Quote._
 import com.datastax.spark.connector.util.{CountingIterator, MergeJoinIterator, NameTools, schemaFromCassandra}
@@ -170,10 +170,13 @@ class CassandraMergeJoinRDD[L,R](
 
     import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
 
-    val fetchResult = asScalaFuture(session.executeAsync(stmt)).map { rs =>
+    val retrier = new ConnectorReadRequestRetrier(fromRDD.readConf.connectorRetry)
+    val fetchResult = asScalaFuture(retrier.executeAsync(stmt, "first-page") {
+      session.executeAsync(stmt)
+    }).map { rs =>
       val columnNames = fromRDD.selectedColumnRefs.map(_.selectedAs).toIndexedSeq ++ Seq(TokenColumn)
       val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs, session)
-      val iterator = new PrefetchingResultSetIterator(rs)
+      val iterator = new PrefetchingResultSetIterator(rs, None, fromRDD.readConf.connectorRetry)
       val iteratorWithMetrics = iterator.map(inputMetricsUpdater.updateMetrics)
       logDebug(s"Row iterator for range $range obtained successfully.")
       (columnMetaData, iteratorWithMetrics)

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableRowReaderProvider.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableRowReaderProvider.scala
@@ -21,6 +21,7 @@ package com.datastax.spark.connector.rdd
 import java.io.IOException
 
 import com.datastax.oss.driver.api.core.ConsistencyLevel
+import com.datastax.oss.driver.api.core.cql.SimpleStatement
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql.{CassandraConnector, TableDef}
 import com.datastax.spark.connector.datasource.ScanHelper
@@ -123,7 +124,9 @@ trait CassandraTableRowReaderProvider[R] {
   protected lazy val cassandraPartitionerClassName =
     connector.withSessionDo {
       session =>
-        session.execute("SELECT partitioner FROM system.local").one().getString(0)
+        session.execute(
+          SimpleStatement.newInstance("SELECT partitioner FROM system.local").setIdempotent(true)
+        ).one().getString(0)
     }
 
   /** Checks for existence of keyspace and table.*/

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
@@ -18,10 +18,138 @@
 
 package com.datastax.spark.connector.rdd
 
-import com.datastax.oss.driver.api.core.{ConsistencyLevel, DefaultConsistencyLevel}
+import java.util.Locale
+
+import com.datastax.oss.driver.api.core.{ConsistencyLevel, DefaultConsistencyLevel, DriverTimeoutException}
+import com.datastax.oss.driver.api.core.servererrors.OverloadedException
 import com.datastax.spark.connector.util.{ConfigCheck, ConfigParameter, DeprecatedConfigParameter, Logging}
 import com.datastax.spark.connector.writer.WriteConf.{ReferenceSection, ThroughputMiBPSParam}
 import org.apache.spark.SparkConf
+
+case class ConnectorReadRetryConf(
+    maxRetries: Int = ConnectorReadRetryConf.DefaultMaxRetries,
+    backoffType: String = ConnectorReadRetryConf.ExponentialBackoff,
+    initialDelayMillis: Int = ConnectorReadRetryConf.DefaultInitialDelayMillis,
+    maxDelayMillis: Int = ConnectorReadRetryConf.DefaultMaxDelayMillis,
+    multiplier: Double = ConnectorReadRetryConf.DefaultMultiplier,
+    jitterFactor: Double = ConnectorReadRetryConf.DefaultJitterFactor,
+    retryOn: Set[String] = ConnectorReadRetryConf.DefaultRetryOn) extends Serializable {
+
+  import ConnectorReadRetryConf._
+
+  require(maxRetries >= 0, "connector read retry maxRetries must be greater than or equal to 0")
+  require(initialDelayMillis >= 0, "connector read retry initialDelayMS must be greater than or equal to 0")
+  require(maxDelayMillis >= initialDelayMillis,
+    "connector read retry maxDelayMS must be greater than or equal to initialDelayMS")
+  require(multiplier >= 1.0d, "connector read retry multiplier must be greater than or equal to 1.0")
+  require(jitterFactor >= 0.0d && jitterFactor <= 1.0d,
+    "connector read retry jitterFactor must be between 0.0 and 1.0")
+  require(BackoffTypes.contains(normalizedBackoffType),
+    s"connector read retry backoff.type must be one of ${BackoffTypes.mkString(", ")}")
+
+  retryOn.foreach(validateThrowableClass)
+
+  def isEnabled: Boolean =
+    maxRetries > 0 && retryOn.nonEmpty
+
+  def normalizedBackoffType: String =
+    backoffType.trim.toLowerCase(Locale.ROOT)
+
+  def retryOnClasses: Set[Class[_ <: Throwable]] =
+    retryOn.flatMap(loadThrowableClasses)
+
+  def delayMillis(attempt: Int): Long =
+    delayMillis(attempt, java.util.concurrent.ThreadLocalRandom.current().nextDouble())
+
+  private[connector] def delayMillis(attempt: Int, randomDouble: Double): Long = {
+    require(attempt >= 1, "retry attempt must be greater than or equal to 1")
+    require(randomDouble >= 0.0d && randomDouble <= 1.0d, "randomDouble must be between 0.0 and 1.0")
+
+    val delayWithoutJitter = normalizedBackoffType match {
+      case ConstBackoff => initialDelayMillis.toDouble
+      case ExponentialBackoff =>
+        initialDelayMillis.toDouble * math.pow(multiplier, attempt - 1)
+    }
+    val cappedDelay = math.min(delayWithoutJitter, maxDelayMillis.toDouble)
+    val jitter = cappedDelay * jitterFactor
+    val jitteredDelay = cappedDelay - jitter + (2.0d * jitter * randomDouble)
+    math.min(maxDelayMillis.toDouble, math.max(0.0d, jitteredDelay)).round
+  }
+}
+
+object ConnectorReadRetryConf {
+  val ConstBackoff = "const"
+  val ExponentialBackoff = "exponential"
+  val BackoffTypes: Set[String] = Set(ConstBackoff, ExponentialBackoff)
+
+  val DefaultMaxRetries = 3
+  val DefaultInitialDelayMillis = 1000
+  val DefaultMaxDelayMillis = 5000
+  val DefaultMultiplier = 2.0d
+  val DefaultJitterFactor = 0.2d
+  val DefaultRetryOn: Set[String] = Set(
+    classOf[DriverTimeoutException].getName,
+    classOf[OverloadedException].getName)
+  val DefaultRetryOnString: String = DefaultRetryOn.toSeq.sorted.mkString(",")
+
+  // Keep this independent from class references so public config names survive driver API relocation.
+  private val PublicDriverClassNamePrefix =
+    Seq("com", "datastax", "oss", "driver").mkString(".") + "."
+  private val DriverTimeoutExceptionClassNameSuffix = "api.core.DriverTimeoutException"
+  private val RuntimeDriverClassNamePrefix = {
+    val className = classOf[DriverTimeoutException].getName
+    if (className.endsWith(DriverTimeoutExceptionClassNameSuffix)) {
+      className.stripSuffix(DriverTimeoutExceptionClassNameSuffix)
+    } else {
+      PublicDriverClassNamePrefix
+    }
+  }
+
+  def parseRetryOn(value: String): Set[String] =
+    value.split(",").iterator.map(_.trim).filter(_.nonEmpty).toSet
+
+  private[connector] def retryOnClassNameCandidates(className: String): Seq[String] = {
+    val exact = Seq(className)
+    val runtimeDriverClassName =
+      if (className.startsWith(PublicDriverClassNamePrefix) &&
+          RuntimeDriverClassNamePrefix != PublicDriverClassNamePrefix) {
+        Seq(RuntimeDriverClassNamePrefix + className.stripPrefix(PublicDriverClassNamePrefix))
+      } else {
+        Seq.empty
+      }
+
+    (exact ++ runtimeDriverClassName).distinct
+  }
+
+  private[connector] def loadThrowableClasses(className: String): Set[Class[_ <: Throwable]] = {
+    val loader = Option(Thread.currentThread().getContextClassLoader)
+      .getOrElse(getClass.getClassLoader)
+    val notFound = scala.collection.mutable.ArrayBuffer.empty[ClassNotFoundException]
+
+    val classes = retryOnClassNameCandidates(className).flatMap { candidate =>
+      try {
+        Some(Class.forName(candidate, false, loader).asSubclass(classOf[Throwable]))
+      } catch {
+        case e: ClassNotFoundException =>
+          notFound += e
+          None
+        case e: ClassCastException =>
+          throw new IllegalArgumentException(s"connector read retry class is not a Throwable: $className", e)
+      }
+    }.toSet
+
+    if (classes.isEmpty) {
+      throw new IllegalArgumentException(
+        s"connector read retry exception class not found: $className",
+        notFound.headOption.orNull)
+    }
+
+    classes
+  }
+
+  private def validateThrowableClass(className: String): Unit =
+    loadThrowableClasses(className)
+}
 
 /** Read settings for RDD
   *
@@ -34,7 +162,8 @@ import org.apache.spark.SparkConf
   * @param taskMetricsEnabled whether or not enable task metrics updates (requires Spark 1.2+)
   * @param readsPerSec maximum read throughput allowed per single core in requests/s while
   *                                  joining an RDD with C* table (joinWithCassandraTable operation)
-  *                                  also used by enterprise integrations*/
+  *                                  also used by enterprise integrations
+  * @param connectorRetry connector-level read request retry settings */
 case class ReadConf(
   splitCount: Option[Int] = None,
   splitSizeInMB: Int = ReadConf.SplitSizeInMBParam.default,
@@ -45,7 +174,8 @@ case class ReadConf(
   readsPerSec: Option[Int] = ReadConf.ReadsPerSecParam.default,
   parallelismLevel: Int = ReadConf.ParallelismLevelParam.default,
   executeAs: Option[String] = None,
-  joinInClauseSize: Int = ReadConf.JoinInClauseSizeParam.default)
+  joinInClauseSize: Int = ReadConf.JoinInClauseSizeParam.default,
+  connectorRetry: ConnectorReadRetryConf = ConnectorReadRetryConf())
 
 
 object ReadConf extends Logging {
@@ -127,6 +257,61 @@ object ReadConf extends Logging {
       """Sets read parallelism for joinWithCassandra tables"""
   )
 
+  val ConnectorRetryMaxRetriesParam = ConfigParameter[Int] (
+    name = "spark.cassandra.input.connectorRetry.maxRetries",
+    section = ReferenceSection,
+    default = ConnectorReadRetryConf.DefaultMaxRetries,
+    description =
+      "Maximum number of connector-level retries for failed read requests. " +
+        "Set to 0 to disable connector-level read retries. This is separate from the Java driver retry policy " +
+        "configured by spark.cassandra.query.retry.count."
+  )
+
+  val ConnectorRetryBackoffTypeParam = ConfigParameter[String] (
+    name = "spark.cassandra.input.connectorRetry.backoff.type",
+    section = ReferenceSection,
+    default = ConnectorReadRetryConf.ExponentialBackoff,
+    description =
+      """Backoff type for connector-level read retries. Valid values are const and exponential."""
+  )
+
+  val ConnectorRetryInitialDelayParam = ConfigParameter[Int] (
+    name = "spark.cassandra.input.connectorRetry.backoff.initialDelayMS",
+    section = ReferenceSection,
+    default = ConnectorReadRetryConf.DefaultInitialDelayMillis,
+    description = """Initial delay in milliseconds for connector-level read retries."""
+  )
+
+  val ConnectorRetryMaxDelayParam = ConfigParameter[Int] (
+    name = "spark.cassandra.input.connectorRetry.backoff.maxDelayMS",
+    section = ReferenceSection,
+    default = ConnectorReadRetryConf.DefaultMaxDelayMillis,
+    description = """Maximum delay in milliseconds for connector-level read retries."""
+  )
+
+  val ConnectorRetryMultiplierParam = ConfigParameter[Double] (
+    name = "spark.cassandra.input.connectorRetry.backoff.multiplier",
+    section = ReferenceSection,
+    default = ConnectorReadRetryConf.DefaultMultiplier,
+    description = """Multiplier used by exponential connector-level read retry backoff."""
+  )
+
+  val ConnectorRetryJitterFactorParam = ConfigParameter[Double] (
+    name = "spark.cassandra.input.connectorRetry.backoff.jitterFactor",
+    section = ReferenceSection,
+    default = ConnectorReadRetryConf.DefaultJitterFactor,
+    description = """Jitter factor for connector-level read retry backoff, between 0.0 and 1.0."""
+  )
+
+  val ConnectorRetryOnParam = ConfigParameter[String] (
+    name = "spark.cassandra.input.connectorRetry.on",
+    section = ReferenceSection,
+    default = ConnectorReadRetryConf.DefaultRetryOnString,
+    description =
+      "Comma-separated fully qualified exception class names retried by connector-level read retry. " +
+        "Retries are attempted only for explicitly idempotent statements."
+  )
+
   val JoinInClauseSizeParam = ConfigParameter[Int] (
     name = "spark.cassandra.input.join.inClauseSize",
     section = ReferenceSection,
@@ -154,9 +339,17 @@ object ReadConf extends Logging {
       throughputMiBPS = conf.getOption(ThroughputMiBPSParam.name).map(_.toDouble),
       readsPerSec = conf.getOption(ReadsPerSecParam.name).map(_.toInt),
       parallelismLevel = conf.getInt(ParallelismLevelParam.name, ParallelismLevelParam.default),
-      joinInClauseSize = conf.getInt(JoinInClauseSizeParam.name, JoinInClauseSizeParam.default)
+      joinInClauseSize = conf.getInt(JoinInClauseSizeParam.name, JoinInClauseSizeParam.default),
+      connectorRetry = ConnectorReadRetryConf(
+        maxRetries = conf.getInt(ConnectorRetryMaxRetriesParam.name, ConnectorRetryMaxRetriesParam.default),
+        backoffType = conf.get(ConnectorRetryBackoffTypeParam.name, ConnectorRetryBackoffTypeParam.default),
+        initialDelayMillis = conf.getInt(ConnectorRetryInitialDelayParam.name, ConnectorRetryInitialDelayParam.default),
+        maxDelayMillis = conf.getInt(ConnectorRetryMaxDelayParam.name, ConnectorRetryMaxDelayParam.default),
+        multiplier = conf.getDouble(ConnectorRetryMultiplierParam.name, ConnectorRetryMultiplierParam.default),
+        jitterFactor = conf.getDouble(ConnectorRetryJitterFactorParam.name, ConnectorRetryJitterFactorParam.default),
+        retryOn = ConnectorReadRetryConf.parseRetryOn(
+          conf.get(ConnectorRetryOnParam.name, ConnectorRetryOnParam.default)))
     )
   }
 
 }
-

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/DataSizeEstimates.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/DataSizeEstimates.scala
@@ -19,7 +19,7 @@
 package com.datastax.spark.connector.rdd.partitioner
 
 import com.datastax.spark.connector.util.Logging
-import com.datastax.oss.driver.api.core.cql.SimpleStatementBuilder
+import com.datastax.oss.driver.api.core.cql.{SimpleStatement, SimpleStatementBuilder}
 import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.rdd.partitioner.dht.{Token, TokenFactory}
@@ -55,10 +55,14 @@ class DataSizeEstimates[V, T <: Token[V]](
     conn.withSessionDo { session =>
       try {
         {
-          val rs = session.execute(new SimpleStatementBuilder(
+          val statement = new SimpleStatementBuilder(
             "SELECT range_start, range_end, partitions_count, mean_partition_size " +
               "FROM system.size_estimates " +
-              "WHERE keyspace_name = ? AND table_name = ?").addPositionalValues(keyspaceName, tableName).build())
+              "WHERE keyspace_name = ? AND table_name = ?")
+            .addPositionalValues(keyspaceName, tableName)
+            .build()
+            .setIdempotent(true)
+          val rs = session.execute(statement)
 
           for (row <- rs.all().asScala) yield TokenRangeSizeEstimate(
             rangeStart = tokenFactory.tokenFromString(row.getString("range_start")),
@@ -121,9 +125,12 @@ object DataSizeEstimates {
 
     conn.withSessionDo { session =>
       def hasSizeEstimates: Boolean = {
-        session.execute(
-          s"SELECT * FROM system.size_estimates " +
-            s"WHERE keyspace_name = '$keyspaceName' AND table_name = '$tableName'").all().asScala.nonEmpty
+        val statement = SimpleStatement
+          .newInstance(
+            s"SELECT * FROM system.size_estimates " +
+              s"WHERE keyspace_name = '$keyspaceName' AND table_name = '$tableName'")
+          .setIdempotent(true)
+        session.execute(statement).all().asScala.nonEmpty
       }
 
       val startTime = System.currentTimeMillis()

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/NodeAddresses.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/NodeAddresses.scala
@@ -20,6 +20,7 @@ package com.datastax.spark.connector.rdd.partitioner
 
 import java.net.InetAddress
 
+import com.datastax.oss.driver.api.core.cql.SimpleStatement
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.util.DriverUtil.{toName, toOption}
 import scala.jdk.CollectionConverters._
@@ -44,7 +45,10 @@ class NodeAddresses(conn: CassandraConnector) extends Serializable {
       val nativeTransportAddressColumnName = transportAddressColumn.map(c => toName(c.getName)).getOrElse("rpc_address")
 
       // TODO: fetch information about the local node from system.local, when CASSANDRA-9436 is done
-      val rs = session.execute(s"SELECT $nativeTransportAddressColumnName, $listenAddressColumnName FROM $table")
+      val statement = SimpleStatement
+        .newInstance(s"SELECT $nativeTransportAddressColumnName, $listenAddressColumnName FROM $table")
+        .setIdempotent(true)
+      val rs = session.execute(statement)
       for {
         row <- rs.all().asScala
         nativeTransportAddress <- Option(row.getInetAddress(nativeTransportAddressColumnName))

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/dht/TokenFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/dht/TokenFactory.scala
@@ -18,6 +18,7 @@
 
 package com.datastax.spark.connector.rdd.partitioner.dht
 
+import com.datastax.oss.driver.api.core.cql.SimpleStatement
 import com.datastax.spark.connector.cql.CassandraConnector
 
 import scala.language.existentials
@@ -114,12 +115,13 @@ object TokenFactory {
 
   def forSystemLocalPartitioner(connector: CassandraConnector): TokenFactory[V, T] = {
     val partitionerClassName = connector.withSessionDo { session =>
-      session.execute("SELECT partitioner FROM system.local").one().getString(0)
+      session.execute(
+        SimpleStatement.newInstance("SELECT partitioner FROM system.local").setIdempotent(true)
+      ).one().getString(0)
     }
     forCassandraPartitioner(partitionerClassName)
   }
 }
-
 
 
 

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/reader/ConnectorReadQueryExecutor.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/reader/ConnectorReadQueryExecutor.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.spark.connector.rdd.reader
+
+import com.datastax.oss.driver.api.core.{AllNodesFailedException, CqlSession, NoNodeAvailableException, NodeUnavailableException}
+import com.datastax.oss.driver.api.core.connection.BusyConnectionException
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet
+import com.datastax.oss.driver.api.core.servererrors.OverloadedException
+import com.datastax.spark.connector.cql.CassandraConnectorConf
+import com.datastax.spark.connector.rdd.{ConnectorReadRetryConf, ReadConf}
+import com.datastax.spark.connector.writer.{AsyncExecutor, RichStatement}
+
+private[connector] object ConnectorReadQueryExecutor {
+
+  private val AsyncExecutorRetryExceptionClasses = Set[Class[_ <: Throwable]](
+    classOf[AllNodesFailedException],
+    classOf[NoNodeAvailableException],
+    classOf[NodeUnavailableException],
+    classOf[BusyConnectionException],
+    classOf[OverloadedException])
+
+  def apply(
+      session: CqlSession,
+      readConf: ReadConf,
+      connectorConf: CassandraConnectorConf): AsyncExecutor[RichStatement, AsyncResultSet] = {
+    val retryConf = withoutAsyncExecutorOverlap(readConf.connectorRetry)
+    val retrier = new ConnectorReadRequestRetrier(retryConf)
+
+    new AsyncExecutor[RichStatement, AsyncResultSet](
+      stmt => {
+        val driverStatement = stmt.stmt
+        retrier.executeAsync(driverStatement, "first-page") {
+          session.executeAsync(driverStatement)
+        }
+      },
+      readConf.parallelismLevel,
+      None,
+      None,
+      maxRetries = connectorConf.queryRetryMaxRetries)
+  }
+
+  private def withoutAsyncExecutorOverlap(conf: ConnectorReadRetryConf): ConnectorReadRetryConf =
+    conf.copy(retryOn = conf.retryOn.filterNot { className =>
+      ConnectorReadRetryConf.loadThrowableClasses(className).exists(AsyncExecutorRetryExceptionClasses.contains)
+    })
+}

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/reader/ConnectorReadRequestRetrier.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/reader/ConnectorReadRequestRetrier.scala
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.spark.connector.rdd.reader
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{CompletableFuture, CompletionException, CompletionStage, ExecutionException, Executors, ScheduledExecutorService, TimeUnit}
+import java.util.function.BiConsumer
+
+import com.datastax.oss.driver.api.core.AllNodesFailedException
+import com.datastax.oss.driver.api.core.cql.Statement
+import com.datastax.spark.connector.rdd.ConnectorReadRetryConf
+import com.datastax.spark.connector.util.Logging
+
+import scala.jdk.CollectionConverters._
+
+private[connector] class ConnectorReadRequestRetrier(conf: ConnectorReadRetryConf) extends Logging {
+
+  import ConnectorReadRequestRetrier._
+
+  def executeAsync[T](
+      statement: Statement[_ <: Statement[_]],
+      phase: String)(
+      action: => CompletionStage[T]): CompletionStage[T] = {
+
+    val result = new CompletableFuture[T]()
+    val retryAttempts = new AtomicInteger(0)
+
+    def tryOnce(): Unit = {
+      if (!result.isDone) {
+        val stage =
+          try {
+            action
+          } catch {
+            case t: Throwable => failedCompletionStage[T](t)
+          }
+
+        stage.whenComplete(new BiConsumer[T, Throwable] {
+          override def accept(value: T, error: Throwable): Unit = {
+            if (error == null) {
+              result.complete(value)
+            } else {
+              val retryAttempt = retryAttempts.incrementAndGet()
+              if (shouldRetry(statement, error, retryAttempt)) {
+                val delayMs = conf.delayMillis(retryAttempt)
+                logTrace(
+                  s"Connector read request retry: phase=$phase " +
+                    s"attempt=$retryAttempt/${conf.maxRetries} backoff=${delayMs}ms " +
+                    s"error=${rootCause(error).getClass.getSimpleName}")
+                RetryScheduler.schedule(new Runnable {
+                  override def run(): Unit = tryOnce()
+                }, delayMs, TimeUnit.MILLISECONDS)
+              } else {
+                logSkippedRetry(statement, phase, error, retryAttempt)
+                result.completeExceptionally(error)
+              }
+            }
+          }
+        })
+      }
+    }
+
+    tryOnce()
+    result
+  }
+
+  private def shouldRetry(
+      statement: Statement[_ <: Statement[_]],
+      error: Throwable,
+      retryAttempt: Int): Boolean =
+    conf.isEnabled &&
+      retryAttempt <= conf.maxRetries &&
+      statement.isIdempotent == java.lang.Boolean.TRUE &&
+      matchesConfiguredException(error, conf)
+
+  private def logSkippedRetry(
+      statement: Statement[_ <: Statement[_]],
+      phase: String,
+      error: Throwable,
+      retryAttempt: Int): Unit = {
+    if (isTraceEnabled() && matchesConfiguredException(error, conf)) {
+      val reason =
+        if (!conf.isEnabled) "disabled"
+        else if (statement.isIdempotent != java.lang.Boolean.TRUE) "non-idempotent"
+        else if (retryAttempt > conf.maxRetries) "exhausted"
+        else "not-retryable"
+      logTrace(
+        s"Connector read request retry skipped: phase=$phase reason=$reason " +
+          s"attempt=$retryAttempt/${conf.maxRetries} error=${rootCause(error).getClass.getSimpleName}")
+    }
+  }
+}
+
+private[reader] object ConnectorReadRequestRetrier {
+
+  private val RetryScheduler: ScheduledExecutorService =
+    Executors.newScheduledThreadPool(1, (r: Runnable) => {
+      val t = new Thread(r, "connector-read-request-retry-scheduler")
+      t.setDaemon(true)
+      t
+    })
+
+  private def failedCompletionStage[T](throwable: Throwable): CompletionStage[T] = {
+    val future = new CompletableFuture[T]()
+    future.completeExceptionally(throwable)
+    future
+  }
+
+  private[reader] def rootCause(throwable: Throwable): Throwable = {
+    def unwrap(t: Throwable): Throwable = t match {
+      case e: CompletionException if e.getCause != null => unwrap(e.getCause)
+      case e: ExecutionException if e.getCause != null => unwrap(e.getCause)
+      case other => other
+    }
+
+    unwrap(throwable)
+  }
+
+  private[reader] def matchesConfiguredException(
+      throwable: Throwable,
+      conf: ConnectorReadRetryConf): Boolean = {
+
+    val retryOnClasses = conf.retryOnClasses
+    val seen = scala.collection.mutable.Set.empty[Throwable]
+
+    def matches(t: Throwable): Boolean = {
+      val error = rootCause(t)
+      if (seen.contains(error)) {
+        false
+      } else {
+        seen += error
+        retryOnClasses.exists(_.isAssignableFrom(error.getClass)) ||
+          Option(error.getCause).exists(matches) ||
+          nestedAllNodesFailures(error).exists(matches)
+      }
+    }
+
+    matches(throwable)
+  }
+
+  private def nestedAllNodesFailures(throwable: Throwable): Iterable[Throwable] = throwable match {
+    case e: AllNodesFailedException =>
+      e.getAllErrors.asScala.values.flatMap(_.asScala)
+    case _ =>
+      Iterable.empty
+  }
+}

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/reader/PrefetchingResultSetIterator.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/reader/PrefetchingResultSetIterator.scala
@@ -18,11 +18,12 @@
 
 package com.datastax.spark.connector.rdd.reader
 
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{CompletionStage, TimeUnit}
 
 import com.codahale.metrics.Timer
 import com.datastax.bdp.util.ScalaJavaUtil
-import com.datastax.oss.driver.api.core.cql.{AsyncResultSet, Row}
+import com.datastax.oss.driver.api.core.cql.{AsyncResultSet, Row, Statement}
+import com.datastax.spark.connector.rdd.ConnectorReadRetryConf
 import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
 
 import scala.concurrent.duration.Duration
@@ -37,15 +38,27 @@ import scala.concurrent.{Await, Future}
   * @param resultSet result set obtained from the Java driver
   * @param timer     a Codahale timer to optionally gather the metrics of fetching time
   */
-class PrefetchingResultSetIterator(resultSet: AsyncResultSet, timer: Option[Timer] = None) extends Iterator[Row] {
+class PrefetchingResultSetIterator(
+    resultSet: AsyncResultSet,
+    timer: Option[Timer],
+    connectorRetryConf: ConnectorReadRetryConf = ConnectorReadRetryConf()) extends Iterator[Row] {
+
+  def this(resultSet: AsyncResultSet) =
+    this(resultSet, None, ConnectorReadRetryConf())
+
+  def this(resultSet: AsyncResultSet, timer: Option[Timer]) =
+    this(resultSet, timer, ConnectorReadRetryConf())
+
+  private val retrier = new ConnectorReadRequestRetrier(connectorRetryConf)
+
   private var currentIterator = resultSet.currentPage().iterator()
   private var currentResultSet = resultSet
   private var nextResultSet = fetchNextPage()
 
   private def fetchNextPage(): Option[Future[AsyncResultSet]] = {
     if (currentResultSet.hasMorePages) {
-      val t0 = System.nanoTime();
-      val next = ScalaJavaUtil.asScalaFuture(currentResultSet.fetchNextPage())
+      val t0 = System.nanoTime()
+      val next = ScalaJavaUtil.asScalaFuture(fetchNextPageWithRetry())
       timer.foreach { t =>
         next.foreach(_ => t.update(System.nanoTime() - t0, TimeUnit.NANOSECONDS))
       }
@@ -53,6 +66,16 @@ class PrefetchingResultSetIterator(resultSet: AsyncResultSet, timer: Option[Time
     } else
       None
   }
+
+  private def fetchNextPageWithRetry(): CompletionStage[AsyncResultSet] =
+    currentResultSet.getExecutionInfo.getRequest match {
+      case statement: Statement[_] =>
+        retrier.executeAsync(statement.asInstanceOf[Statement[_ <: Statement[_]]], "next-page") {
+          currentResultSet.fetchNextPage()
+        }
+      case _ =>
+        currentResultSet.fetchNextPage()
+    }
 
   private def maybePrefetch(): Unit = {
     if (!currentIterator.hasNext && currentResultSet.hasMorePages) {

--- a/connector/src/main/scala/com/datastax/spark/connector/util/PatitionKeyTools.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/util/PatitionKeyTools.scala
@@ -21,7 +21,7 @@ package com.datastax.spark.connector.util
 import java.io.IOException
 
 import com.datastax.oss.driver.api.core.CqlSession
-import com.datastax.oss.driver.api.core.cql.PreparedStatement
+import com.datastax.oss.driver.api.core.cql.{PreparedStatement, SimpleStatement}
 import com.datastax.spark.connector.cql.{ColumnDef, TableDef}
 import com.datastax.spark.connector.util.Quote._
 
@@ -42,7 +42,10 @@ object PatitionKeyTools {
 
   private[connector] def prepareDummyStatement(session: CqlSession, tableDef: TableDef): PreparedStatement = {
     try {
-      session.prepare(querySelectUsingOnlyPartitionKeys(tableDef))
+      val statement = SimpleStatement
+        .newInstance(querySelectUsingOnlyPartitionKeys(tableDef))
+        .setIdempotent(true)
+      session.prepare(statement)
     }
     catch {
       case t: Throwable =>

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/SolrPredicateRules.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/SolrPredicateRules.scala
@@ -130,7 +130,7 @@ class SolrPredicateRules(searchOptimizationEnabled: DseSearchOptimizationSetting
 
     Try {
       CassandraConnector(sparkConf)
-        .withSessionDo(_.execute(SelectSolrSchema))
+        .withSessionDo(_.execute(SimpleStatement.newInstance(SelectSolrSchema).setIdempotent(true)))
         .one()
         .getString(0)
     } match {
@@ -400,8 +400,10 @@ class SolrPredicateRules(searchOptimizationEnabled: DseSearchOptimizationSetting
             val pagingDisabled = session.getContext.getConfig.getDefaultProfile.withInt(DefaultDriverOption.REQUEST_PAGE_SIZE, -1)
             val totalRequest = SimpleStatement.newInstance(request, s"""{"q":"*:*", $FaultTolerant}""")
               .setExecutionProfile(pagingDisabled)
+              .setIdempotent(true)
             val queryRequest = SimpleStatement.newInstance(request, solrStringNoFailoverTolerant)
               .setExecutionProfile(pagingDisabled)
+              .setIdempotent(true)
 
             val totalFuture = session.executeAsync(totalRequest)
             val queryFuture = session.executeAsync(queryRequest)//TODO THIS can be done in a more reactive way I believe

--- a/connector/src/test/scala/com/datastax/spark/connector/datasource/JoinHelperTest.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/datasource/JoinHelperTest.scala
@@ -18,12 +18,27 @@
 
 package com.datastax.spark.connector.datasource
 
+import java.nio.ByteBuffer
+import java.util.{Collections => JCollections}
+
+import com.datastax.oss.driver.api.core.{CqlIdentifier, ProtocolVersion, RequestRoutingType}
+import com.datastax.oss.driver.api.core.`type`.codec.registry.CodecRegistry
+import com.datastax.oss.driver.api.core.cql.{ColumnDefinition, ColumnDefinitions, PreparedStatement}
+import com.datastax.oss.driver.internal.core.cql.{
+  DefaultColumnDefinition,
+  DefaultColumnDefinitions,
+  DefaultPreparedStatement}
+import com.datastax.oss.protocol.internal.ProtocolConstants
+import com.datastax.oss.protocol.internal.response.result.{ColumnSpec, RawType}
 import com.datastax.spark.connector.{ColumnName, SomeColumns}
 import com.datastax.spark.connector.cql.{ClusteringColumn, ColumnDef, PartitionKeyColumn, RegularColumn, TableDef}
 import com.datastax.spark.connector.datasource.ScanHelper.CqlQueryParts
 import com.datastax.spark.connector.rdd.CqlWhereClause
 import com.datastax.spark.connector.types.{IntType, TextType}
+import com.datastax.spark.connector.writer.RowWriter
 import org.junit.{Assert, Test}
+
+import scala.jdk.CollectionConverters._
 
 class JoinHelperTest {
 
@@ -63,5 +78,73 @@ class JoinHelperTest {
     Assert.assertTrue(query, query.contains("\"UserId\" = :\"UserId\""))
     Assert.assertTrue(query, query.contains("\"TenantId\" = :\"TenantId\""))
     Assert.assertTrue(query, query.contains("\"GroupId\" IN (?, ?)"))
+  }
+
+  @Test
+  def bindInClauseStatementShouldMarkReadStatementIdempotent(): Unit = {
+    val preparedStatement = preparedStatementWithVariables(
+      "where_value" -> ProtocolConstants.DataType.INT,
+      "UserId" -> ProtocolConstants.DataType.INT,
+      "TenantId" -> ProtocolConstants.DataType.INT,
+      "GroupId" -> ProtocolConstants.DataType.INT,
+      "GroupId" -> ProtocolConstants.DataType.INT)
+    val rowWriter = new RowWriter[Seq[Any]] {
+      override def columnNames: Seq[String] = Seq("UserId", "TenantId", "GroupId")
+      override def readColumnValues(data: Seq[Any], buffer: Array[Any]): Unit =
+        data.zipWithIndex.foreach { case (value, index) => buffer(index) = value }
+    }
+
+    val bound = JoinHelper.bindInClauseStatement(
+      Seq(Seq(1, 2, 3), Seq(1, 2, 4)),
+      preparedStatement,
+      rowWriter,
+      CodecRegistry.DEFAULT,
+      prefixVals = Seq(99),
+      pkIndices = Seq(0),
+      ckEqIndices = Seq(1),
+      lastCkIndex = 2)
+
+    Assert.assertEquals(java.lang.Boolean.TRUE, bound.isIdempotent)
+    Assert.assertEquals(99, bound.getInt(0))
+    Assert.assertEquals(1, bound.getInt(1))
+    Assert.assertEquals(2, bound.getInt(2))
+    Assert.assertEquals(3, bound.getInt(3))
+    Assert.assertEquals(4, bound.getInt(4))
+  }
+
+  private def columnDefinitions(columns: (String, Int)*): ColumnDefinitions = {
+    DefaultColumnDefinitions.valueOf(columns.zipWithIndex.map { case ((name, dataType), index) =>
+      val columnSpec = new ColumnSpec("ks", "tab", name, index, RawType.PRIMITIVES.get(dataType))
+      new DefaultColumnDefinition(columnSpec, null).asInstanceOf[ColumnDefinition]
+    }.toList.asJava)
+  }
+
+  private def preparedStatementWithVariables(columns: (String, Int)*): PreparedStatement = {
+    new DefaultPreparedStatement(
+      ByteBuffer.wrap(Array[Byte](1)),
+      "test query",
+      columnDefinitions(columns: _*),
+      JCollections.emptyList[java.lang.Integer](),
+      null,
+      columnDefinitions(),
+      CqlIdentifier.fromInternal("ks"),
+      null,
+      JCollections.emptyMap[String, ByteBuffer](),
+      null,
+      null,
+      CqlIdentifier.fromInternal("tab"),
+      null,
+      null,
+      JCollections.emptyMap[String, ByteBuffer](),
+      java.lang.Boolean.TRUE,
+      null,
+      null,
+      0,
+      null,
+      null,
+      false,
+      CodecRegistry.DEFAULT,
+      ProtocolVersion.DEFAULT,
+      RequestRoutingType.REGULAR)
   }
 }

--- a/connector/src/test/scala/com/datastax/spark/connector/rdd/ReadConfSpec.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/rdd/ReadConfSpec.scala
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.spark.connector.rdd
+
+import com.datastax.oss.driver.api.core.DriverTimeoutException
+import com.datastax.oss.driver.api.core.servererrors.OverloadedException
+import org.apache.spark.SparkConf
+import org.scalatest.{FlatSpec, Matchers}
+
+class ReadConfSpec extends FlatSpec with Matchers {
+
+  "ReadConf" should "load connector read retry defaults" in {
+    val retryConf = ReadConf.fromSparkConf(new SparkConf(false)).connectorRetry
+
+    retryConf.maxRetries shouldBe 3
+    retryConf.normalizedBackoffType shouldBe ConnectorReadRetryConf.ExponentialBackoff
+    retryConf.initialDelayMillis shouldBe 1000
+    retryConf.maxDelayMillis shouldBe 5000
+    retryConf.multiplier shouldBe 2.0d
+    retryConf.jitterFactor shouldBe 0.2d
+    retryConf.retryOn should contain (classOf[DriverTimeoutException].getName)
+    retryConf.retryOn should contain (classOf[OverloadedException].getName)
+    retryConf.retryOnClasses should contain (classOf[DriverTimeoutException])
+    retryConf.retryOnClasses should contain (classOf[OverloadedException])
+  }
+
+  it should "load connector read retry overrides" in {
+    val conf = new SparkConf(false)
+      .set(ReadConf.ConnectorRetryMaxRetriesParam.name, "7")
+      .set(ReadConf.ConnectorRetryBackoffTypeParam.name, ConnectorReadRetryConf.ConstBackoff)
+      .set(ReadConf.ConnectorRetryInitialDelayParam.name, "11")
+      .set(ReadConf.ConnectorRetryMaxDelayParam.name, "13")
+      .set(ReadConf.ConnectorRetryMultiplierParam.name, "1.5")
+      .set(ReadConf.ConnectorRetryJitterFactorParam.name, "0.0")
+      .set(ReadConf.ConnectorRetryOnParam.name, classOf[DriverTimeoutException].getName)
+
+    val retryConf = ReadConf.fromSparkConf(conf).connectorRetry
+
+    retryConf.maxRetries shouldBe 7
+    retryConf.normalizedBackoffType shouldBe ConnectorReadRetryConf.ConstBackoff
+    retryConf.initialDelayMillis shouldBe 11
+    retryConf.maxDelayMillis shouldBe 13
+    retryConf.multiplier shouldBe 1.5d
+    retryConf.jitterFactor shouldBe 0.0d
+    retryConf.retryOn shouldBe Set(classOf[DriverTimeoutException].getName)
+  }
+
+  it should "disable connector read retries with maxRetries zero" in {
+    ConnectorReadRetryConf(maxRetries = 0).isEnabled shouldBe false
+  }
+
+  it should "disable connector read retries with an empty retry list" in {
+    val conf = new SparkConf(false)
+      .set(ReadConf.ConnectorRetryOnParam.name, "")
+
+    ReadConf.fromSparkConf(conf).connectorRetry.isEnabled shouldBe false
+  }
+
+  "ConnectorReadRetryConf" should "calculate exponential backoff with a hard maximum delay" in {
+    val conf = ConnectorReadRetryConf(
+      initialDelayMillis = 100,
+      maxDelayMillis = 350,
+      multiplier = 2.0d,
+      jitterFactor = 0.0d)
+
+    conf.delayMillis(1, 0.5d) shouldBe 100L
+    conf.delayMillis(2, 0.5d) shouldBe 200L
+    conf.delayMillis(3, 0.5d) shouldBe 350L
+  }
+
+  it should "calculate constant backoff" in {
+    val conf = ConnectorReadRetryConf(
+      backoffType = ConnectorReadRetryConf.ConstBackoff,
+      initialDelayMillis = 100,
+      maxDelayMillis = 350,
+      jitterFactor = 0.0d)
+
+    conf.delayMillis(1, 0.5d) shouldBe 100L
+    conf.delayMillis(3, 0.5d) shouldBe 100L
+  }
+
+  it should "apply jitter without exceeding maximum delay" in {
+    val conf = ConnectorReadRetryConf(
+      initialDelayMillis = 100,
+      maxDelayMillis = 100,
+      jitterFactor = 0.5d)
+
+    conf.delayMillis(1, 0.0d) shouldBe 50L
+    conf.delayMillis(1, 1.0d) shouldBe 100L
+  }
+
+  it should "reject unknown retry exception classes" in {
+    intercept[IllegalArgumentException] {
+      ConnectorReadRetryConf(retryOn = Set("not.a.RealException"))
+    }.getMessage should include ("exception class not found")
+  }
+
+  it should "reject retry exception classes that are not throwables" in {
+    intercept[IllegalArgumentException] {
+      ConnectorReadRetryConf(retryOn = Set(classOf[String].getName))
+    }.getMessage should include ("not a Throwable")
+  }
+
+  it should "resolve retry exception class names from driver runtime classes" in {
+    ConnectorReadRetryConf.loadThrowableClasses(classOf[DriverTimeoutException].getName) shouldBe
+      Set(classOf[DriverTimeoutException])
+    ConnectorReadRetryConf.loadThrowableClasses(classOf[OverloadedException].getName) shouldBe
+      Set(classOf[OverloadedException])
+  }
+}

--- a/connector/src/test/scala/com/datastax/spark/connector/rdd/reader/ConnectorReadRequestRetrierSpec.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/rdd/reader/ConnectorReadRequestRetrierSpec.scala
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.spark.connector.rdd.reader
+
+import java.util.HashMap
+import java.util.concurrent.{CompletableFuture, CompletionStage, ExecutionException, TimeUnit}
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.cql.{AsyncResultSet, BoundStatement, ExecutionInfo, Row}
+import com.datastax.oss.driver.api.core.metadata.Node
+import com.datastax.oss.driver.api.core.{AllNodesFailedException, DriverTimeoutException}
+import com.datastax.oss.driver.api.core.servererrors.OverloadedException
+import com.datastax.spark.connector.cql.CassandraConnectorConf
+import com.datastax.spark.connector.rdd.{ConnectorReadRetryConf, ReadConf}
+import com.datastax.spark.connector.writer.RichBoundStatementWrapper
+import org.mockito.Mockito._
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+
+class ConnectorReadRequestRetrierSpec extends FlatSpec with Matchers with MockitoSugar {
+
+  private val retryConf = ConnectorReadRetryConf(
+    initialDelayMillis = 0,
+    maxDelayMillis = 0,
+    jitterFactor = 0.0d,
+    retryOn = Set(classOf[DriverTimeoutException].getName))
+
+  "ConnectorReadRequestRetrier" should "retry configured failures for idempotent statements" in {
+    val statement = idempotentStatement(true)
+    val retrier = new ConnectorReadRequestRetrier(retryConf)
+    var calls = 0
+
+    val result = retrier.executeAsync(statement, "first-page") {
+      calls += 1
+      if (calls == 1) failedStage(new DriverTimeoutException("timeout"))
+      else CompletableFuture.completedFuture("ok")
+    }
+
+    result.toCompletableFuture.get(5, TimeUnit.SECONDS) shouldBe "ok"
+    calls shouldBe 2
+  }
+
+  it should "not retry non-idempotent statements" in {
+    val statement = idempotentStatement(false)
+    val retrier = new ConnectorReadRequestRetrier(retryConf)
+    var calls = 0
+
+    val result = retrier.executeAsync(statement, "first-page") {
+      calls += 1
+      failedStage[String](new DriverTimeoutException("timeout"))
+    }
+
+    intercept[ExecutionException] {
+      result.toCompletableFuture.get(5, TimeUnit.SECONDS)
+    }.getCause shouldBe a[DriverTimeoutException]
+    calls shouldBe 1
+  }
+
+  it should "not retry statements without explicit idempotency" in {
+    val statement = statementWithIdempotence(null)
+    val retrier = new ConnectorReadRequestRetrier(retryConf)
+    var calls = 0
+
+    val result = retrier.executeAsync(statement, "first-page") {
+      calls += 1
+      failedStage[String](new DriverTimeoutException("timeout"))
+    }
+
+    intercept[ExecutionException] {
+      result.toCompletableFuture.get(5, TimeUnit.SECONDS)
+    }.getCause shouldBe a[DriverTimeoutException]
+    calls shouldBe 1
+  }
+
+  it should "not retry when disabled" in {
+    val statement = idempotentStatement(true)
+    val retrier = new ConnectorReadRequestRetrier(retryConf.copy(maxRetries = 0))
+    var calls = 0
+
+    val result = retrier.executeAsync(statement, "first-page") {
+      calls += 1
+      failedStage[String](new DriverTimeoutException("timeout"))
+    }
+
+    intercept[ExecutionException] {
+      result.toCompletableFuture.get(5, TimeUnit.SECONDS)
+    }.getCause shouldBe a[DriverTimeoutException]
+    calls shouldBe 1
+  }
+
+  it should "not retry exceptions missing from the configured list" in {
+    val statement = idempotentStatement(true)
+    val retrier = new ConnectorReadRequestRetrier(retryConf)
+    var calls = 0
+    val failure = new IllegalStateException("not transient")
+
+    val result = retrier.executeAsync(statement, "first-page") {
+      calls += 1
+      failedStage[String](failure)
+    }
+
+    intercept[ExecutionException] {
+      result.toCompletableFuture.get(5, TimeUnit.SECONDS)
+    }.getCause shouldBe failure
+    calls shouldBe 1
+  }
+
+  it should "match configured exception classes nested inside AllNodesFailedException" in {
+    val node = mock[Node]
+    val errors = new HashMap[Node, Throwable]()
+    errors.put(node, new DriverTimeoutException("timeout"))
+    val failure = AllNodesFailedException.fromErrors(errors)
+
+    ConnectorReadRequestRetrier.matchesConfiguredException(failure, retryConf) shouldBe true
+  }
+
+  it should "match the default retry exception classes" in {
+    val node = mock[Node]
+    val conf = ConnectorReadRetryConf(initialDelayMillis = 0, maxDelayMillis = 0, jitterFactor = 0.0d)
+
+    ConnectorReadRequestRetrier.matchesConfiguredException(
+      new DriverTimeoutException("timeout"), conf) shouldBe true
+    ConnectorReadRequestRetrier.matchesConfiguredException(
+      new OverloadedException(node, "overloaded"), conf) shouldBe true
+  }
+
+  "PrefetchingResultSetIterator" should "retry failed next-page fetches" in {
+    val statement = idempotentStatement(true)
+    val row1 = mock[Row]
+    val row2 = mock[Row]
+    val firstPage = resultSet(statement, Seq(row1), hasMorePages = true)
+    val secondPage = resultSet(statement, Seq(row2), hasMorePages = false)
+
+    when(firstPage.fetchNextPage())
+      .thenReturn(
+        failedStage[AsyncResultSet](new DriverTimeoutException("timeout")),
+        CompletableFuture.completedFuture(secondPage))
+
+    val iterator = new PrefetchingResultSetIterator(firstPage, None, retryConf)
+
+    iterator.next() shouldBe row1
+    iterator.next() shouldBe row2
+    iterator.hasNext shouldBe false
+    verify(firstPage, times(2)).fetchNextPage()
+  }
+
+  "ConnectorReadQueryExecutor" should "retry first-page client timeouts before completing the task future" in {
+    val session = mock[CqlSession]
+    val connectorConf = mock[CassandraConnectorConf]
+    val statement = idempotentStatement(true)
+    val resultSet = mock[AsyncResultSet]
+    val readConf = ReadConf(parallelismLevel = 1, connectorRetry = retryConf)
+
+    when(connectorConf.queryRetryMaxRetries).thenReturn(0)
+    val executor = ConnectorReadQueryExecutor(session, readConf, connectorConf)
+    when(session.executeAsync(statement))
+      .thenReturn(
+        failedStage[AsyncResultSet](new DriverTimeoutException("timeout")),
+        CompletableFuture.completedFuture(resultSet))
+
+    Await.result(executor.executeAsync(new RichBoundStatementWrapper(statement)), 5.seconds) shouldBe resultSet
+    verify(session, times(2)).executeAsync(statement)
+  }
+
+  private def idempotentStatement(value: Boolean): BoundStatement = {
+    statementWithIdempotence(Boolean.box(value))
+  }
+
+  private def statementWithIdempotence(value: java.lang.Boolean): BoundStatement = {
+    val statement = mock[BoundStatement]
+    when(statement.isIdempotent).thenReturn(value)
+    statement
+  }
+
+  private def resultSet(
+      statement: BoundStatement,
+      rows: Seq[Row],
+      hasMorePages: Boolean): AsyncResultSet = {
+    val resultSet = mock[AsyncResultSet]
+    val executionInfo = mock[ExecutionInfo]
+    doReturn(statement).when(executionInfo).getRequest
+    when(resultSet.getExecutionInfo).thenReturn(executionInfo)
+    when(resultSet.currentPage()).thenReturn(rows.asJava)
+    when(resultSet.hasMorePages).thenReturn(hasMorePages)
+    resultSet
+  }
+
+  private def failedStage[T](throwable: Throwable): CompletionStage[T] = {
+    val future = new CompletableFuture[T]()
+    future.completeExceptionally(throwable)
+    future
+  }
+}

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -128,6 +128,7 @@ while the application is running.</td>
   <td>60</td>
   <td>Number of times to retry a timed-out query
 Setting this to -1 means unlimited retries
+This configures the Java driver retry policy, not connector-level read request retry.
       </td>
 </tr>
 <tr>
@@ -335,6 +336,41 @@ columname will be used to set the writetime for that row.</td>
   <td><code>spark.cassandra.concurrent.reads</code></td>
   <td>512</td>
   <td>Sets read parallelism for joinWithCassandra tables</td>
+</tr>
+<tr>
+  <td><code>spark.cassandra.input.connectorRetry.backoff.initialDelayMS</code></td>
+  <td>1000</td>
+  <td>Initial delay in milliseconds for connector-level read retries.</td>
+</tr>
+<tr>
+  <td><code>spark.cassandra.input.connectorRetry.backoff.jitterFactor</code></td>
+  <td>0.2</td>
+  <td>Jitter factor for connector-level read retry backoff, between 0.0 and 1.0.</td>
+</tr>
+<tr>
+  <td><code>spark.cassandra.input.connectorRetry.backoff.maxDelayMS</code></td>
+  <td>5000</td>
+  <td>Maximum delay in milliseconds for connector-level read retries.</td>
+</tr>
+<tr>
+  <td><code>spark.cassandra.input.connectorRetry.backoff.multiplier</code></td>
+  <td>2.0</td>
+  <td>Multiplier used by exponential connector-level read retry backoff.</td>
+</tr>
+<tr>
+  <td><code>spark.cassandra.input.connectorRetry.backoff.type</code></td>
+  <td>exponential</td>
+  <td>Backoff type for connector-level read retries. Valid values are const and exponential.</td>
+</tr>
+<tr>
+  <td><code>spark.cassandra.input.connectorRetry.maxRetries</code></td>
+  <td>3</td>
+  <td>Maximum number of connector-level retries for failed read requests. Set to 0 to disable connector-level read retries. This is separate from the Java driver retry policy configured by spark.cassandra.query.retry.count.</td>
+</tr>
+<tr>
+  <td><code>spark.cassandra.input.connectorRetry.on</code></td>
+  <td>com.datastax.oss.driver.api.core.DriverTimeoutException,com.datastax.oss.driver.api.core.servererrors.OverloadedException</td>
+  <td>Comma-separated fully qualified exception class names retried by connector-level read retry. Retries are attempted only for explicitly idempotent statements.</td>
 </tr>
 <tr>
   <td><code>spark.cassandra.input.consistency.level</code></td>


### PR DESCRIPTION
## Rationale

Fixes #117 by adding a connector-level retry layer around read requests that complete exceptionally after the Java driver has already made its own retry-policy decisions. This covers first-page `executeAsync` calls and subsequent `fetchNextPage()` calls without changing the existing in-driver retry policy.

The retry is limited to explicitly idempotent statements. Idempotency is intentionally not configurable. Connector-generated read statements now set the driver idempotency flag explicitly on scan, join, IN-clause join, merge/co-group scan, metadata, and Solr probe SELECT paths.

## Configuration

New read configs under `spark.cassandra.input.connectorRetry.*`:

- `maxRetries` default `3`; set to `0` to disable connector-level read retry
- `on` default `com.datastax.oss.driver.api.core.DriverTimeoutException,com.datastax.oss.driver.api.core.servererrors.OverloadedException`; set to empty to disable by exception list
- `backoff.type` default `exponential`, allowed `const` or `exponential`
- `backoff.initialDelayMS` default `1000`
- `backoff.maxDelayMS` default `5000`
- `backoff.multiplier` default `2.0`
- `backoff.jitterFactor` default `0.2`

## Notes

`spark.cassandra.query.retry.count` remains the Java driver retry-policy setting. This PR adds connector-level retries only after the driver request completes with a configured exception. Join read paths keep the existing `AsyncExecutor` retry behavior and avoid duplicating connector retry for exception classes already handled there.

The current connector assembly and `com.scylladb:java-driver-core-shaded:4.19.2.0` keep `DriverTimeoutException`, `OverloadedException`, and `AllNodesFailedException` under `com.datastax.oss.driver.api...`; only driver internals are under `com.datastax.oss.driver.shaded...`. The built-in defaults and AsyncExecutor overlap filter now derive from runtime driver class references, and configured public driver class names can resolve to relocated runtime driver classes if a future packaging rule changes that path.

DDL, truncate, user-provided CQL, and writer templates are not broadly marked idempotent. Writer execution keeps the existing per-statement idempotency calculation for deletes, counters, and collection mutations.

## Tests

- `PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./sbt/sbt "connector/testOnly com.datastax.spark.connector.rdd.ReadConfSpec com.datastax.spark.connector.rdd.reader.ConnectorReadRequestRetrierSpec"`
- `PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./sbt/sbt connector/assembly`
- `jar tf connector/target/scala-2.13/spark-scylladb-connector-assembly-4.1.5-SNAPSHOT.jar | rg "DriverTimeoutException|OverloadedException|AllNodesFailedException"`
- `PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 make lint`
- `git diff --check`
- `PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./sbt/sbt test`